### PR TITLE
Add unit tests for width/height parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,6 @@ target_link_libraries(autonomous_car PRIVATE
     stdc++
     yaml-cpp
 )
+
+enable_testing()
+add_subdirectory(tests)

--- a/include/auto_vehicle.h
+++ b/include/auto_vehicle.h
@@ -5,6 +5,7 @@
 #include "olcPixelGameEngine.h"
 #include "logger.h"
 #include "vehicle.h"
+#include "utils.h"
 
 namespace autonomous_driving
 {

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,32 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <sstream>
+#include <string>
+
+namespace autonomous_driving {
+
+template <typename T>
+bool extractWidthHeight(const std::string& window_size, T& width, T& height) {
+    size_t xPos = window_size.find('x');
+    if (xPos == std::string::npos || xPos >= window_size.length()) {
+        return false;
+    }
+
+    std::stringstream first(window_size.substr(0, xPos));
+    std::stringstream second(window_size.substr(xPos + 1));
+
+    T w{};
+    T h{};
+    if (!(first >> w) || !(second >> h)) {
+        return false;
+    }
+
+    width = w;
+    height = h;
+    return true;
+}
+
+} // namespace autonomous_driving
+
+#endif // UTILS_H

--- a/src/auto_vehicle.cpp
+++ b/src/auto_vehicle.cpp
@@ -1,5 +1,6 @@
 #define OLC_PGE_APPLICATION
 #include "auto_vehicle.h"
+#include "utils.h"
 #include "yaml-cpp/yaml.h"
 
 ////////////////////////////////////////////////////////:- Autonomous Vehicle Class -:////////////////////////////////////////////////////////
@@ -122,18 +123,7 @@ void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig
     std::printf("[INFO]: Initial position is %fx%f \n", gameConfig.xPosition, gameConfig.yPosition);
 }
 
-template <typename T>
-bool autonomous_driving::extractWidthHeight(const std::string& window_size, T& width, T& height){
-    size_t xPos = window_size.find('x');
-    if (xPos != std::string::npos && xPos < window_size.length()){
-        width = std::stoll(window_size.substr(0, xPos));
-        height = std::stoll(window_size.substr(xPos + 1));
-        return true;
-    } else
-    {
-        return false;
-    }   
-}
+
 
 ////////////////////////////////////////////////////////////:- Main Method -:////////////////////////////////////////////////////////////
 int main(int argc, char* argv[]){

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(parse_tests parse_tests.cpp)
+
+add_test(NAME parse_tests COMMAND parse_tests)

--- a/tests/parse_tests.cpp
+++ b/tests/parse_tests.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+#include <cmath>
+#include "utils.h"
+
+int main() {
+    int w = 0, h = 0;
+    bool ok = autonomous_driving::extractWidthHeight<int>("1920x1080", w, h);
+    assert(ok);
+    assert(w == 1920 && h == 1080);
+
+    float wf = 0.f, hf = 0.f;
+    ok = autonomous_driving::extractWidthHeight<float>("10.5x20.25", wf, hf);
+    assert(ok);
+    assert(std::fabs(wf - 10.5f) < 1e-6f);
+    assert(std::fabs(hf - 20.25f) < 1e-6f);
+
+    int badW = 0, badH = 0;
+    ok = autonomous_driving::extractWidthHeight<int>("1920-1080", badW, badH);
+    assert(!ok);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a generic `extractWidthHeight` utility
- use the new header in the project
- add assert-based tests for parsing strings
- enable CTest and build tests via CMake

## Testing
- `cmake --build build --target parse_tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68790925cf64832296fbd5ccde1dcf8e