### PR TITLE
Fix CI workflow for CMake project

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libgl1-mesa-dev libpng-dev libyaml-cpp-dev
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure


### PR DESCRIPTION
## Summary
- update GitHub workflow to use CMake build system
- install required system packages

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing olcPixelGameEngine submodule)*
- `ctest --output-on-failure` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_6879105e20f48322af7cd2f2e59f5348