### PR TITLE
Fix CI submodule checkout

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: configure
       run: ./configure
     - name: make


### PR DESCRIPTION
## Summary
- ensure olcPixelGameEngine submodule is checked out during CI

## Testing
- `cmake ..`
- `make` *(fails: `olcPixelGameEngine.h` not found)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687913241d208322a15787e81dd3490d