### PR TITLE
Fix CI checkout with submodules

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,16 +8,18 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libgl1-mesa-dev libpng-dev libyaml-cpp-dev
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure


### PR DESCRIPTION
## Summary
- update GitHub workflow to install packages with CMake build
- checkout submodules recursively so the build can find olcPixelGameEngine

## Testing
- `cmake -S . -B build` *(fails: missing submodule)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687918daeb448322a4a4ced375aaf950