### PR TITLE
Add robotics range sensor scenario mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,22 +11,27 @@ include_directories(${CMAKE_SOURCE_DIR}/Configs)
 include_directories(${CMAKE_SOURCE_DIR}/Assets)
 include_directories(${CMAKE_SOURCE_DIR}/libraries/olcPixelGameEngine)
 
-# Add Source file
-add_executable(autonomous_car
-    src/auto_vehicle.cpp
-    src/logger.cpp
-    src/vehicle.cpp
-)
+set(OLC_PGE_HEADER ${CMAKE_SOURCE_DIR}/libraries/olcPixelGameEngine/olcPixelGameEngine.h)
+if(EXISTS ${OLC_PGE_HEADER})
+    # Add Source file
+    add_executable(autonomous_car
+        src/auto_vehicle.cpp
+        src/logger.cpp
+        src/vehicle.cpp
+    )
 
-# Target Link libraries
-target_link_libraries(autonomous_car PRIVATE
-    X11
-    GL
-    pthread
-    png
-    stdc++
-    yaml-cpp
-)
+    # Target Link libraries
+    target_link_libraries(autonomous_car PRIVATE
+        X11
+        GL
+        pthread
+        png
+        stdc++
+        yaml-cpp
+    )
+else()
+    message(WARNING "olcPixelGameEngine.h was not found. Skipping autonomous_car; run `git submodule update --init --recursive` to build the simulator executable.")
+endif()
 
 enable_testing()
 add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A 2D car simulator built with [olcPixelGameEngine](https://github.com/OneLoneCod
 
 ---
 
+## Product Focus
+
+Robotics engineers repeatedly report that simulation is useful for reducing slow, risky hardware iteration, but that two issues limit its value: the sim-to-real gap and the difficulty of automating realistic sensor/perception tests. AutoSIM is still a lightweight 2D simulator, so it cannot replace Gazebo, Isaac Sim, MuJoCo, or hardware-in-the-loop validation. It can, however, add practical value as a fast smoke-test sandbox for navigation logic by making obstacle layouts, noisy range readings, and sensor dropouts configurable and repeatable.
+
 ## Features
 
 - Arrow key controls (forward, backward, left, right)
@@ -14,6 +18,8 @@ A 2D car simulator built with [olcPixelGameEngine](https://github.com/OneLoneCod
 - Screen wrapping — driving off one edge brings you back on the opposite side
 - Configuration loaded from a YAML file (no recompile needed to change settings)
 - Built-in logger with INFO / WARNING / ERROR levels
+- Robotics scenario overlay with configurable rectangular obstacles
+- Deterministic 2D range sensor simulator with field-of-view, ray count, max range, Gaussian noise, dropout rate, and seed controls
 
 ---
 
@@ -68,6 +74,18 @@ Edit `configs/initializeGame.yaml` to change the startup settings:
 car_png: "../assets/car.png"       # Path to the car sprite
 window_size: "1980x1080"           # Window width x height
 initial_position: "100x100"        # Starting X x Y position of the car
+
+robotics_overlay: true              # Draw obstacles, range rays, and HUD
+obstacles:                          # x/y/width/height rectangles in pixels
+  - "460x220x160x90"
+  - "820x520x130x220"
+range_sensor:
+  rays: 41                          # Number of simulated range beams
+  fov_degrees: 180                  # Sensor field of view
+  max_range: 420                    # Maximum beam distance in pixels
+  noise_stddev: 2.5                 # Gaussian range noise in pixels
+  dropout_rate: 0.03                # Probability a reading returns max range
+  random_seed: 42                   # Repeatable noise/dropout sequence
 ```
 
 ---
@@ -80,6 +98,18 @@ initial_position: "100x100"        # Starting X x Y position of the car
 | ↓ Down     | Reverse         |
 | ← Left     | Rotate left     |
 | → Right    | Rotate right    |
+
+---
+
+## Robotics Engineer Mode
+
+The robotics overlay is designed for early navigation and perception smoke tests:
+
+1. Add obstacle rectangles to `configs/initializeGame.yaml`.
+2. Tune the range sensor model to mimic imperfect low-cost lidar, sonar, IR, or depth preprocessing.
+3. Use the deterministic `random_seed` to reproduce a failure case, then increase `noise_stddev` or `dropout_rate` to check robustness.
+
+This feature intentionally solves a small pain point: quick, repeatable testing of obstacle-avoidance assumptions before spending time in a heavier simulator or on physical hardware. It does **not** claim physical fidelity, wheel slip, 3D contact dynamics, ROS integration, or camera-realistic synthetic data.
 
 ---
 

--- a/configs/initializeGame.yaml
+++ b/configs/initializeGame.yaml
@@ -1,3 +1,19 @@
 car_png: "../assets/car.png"
 window_size: "1980x1080"
 initial_position: "100x100"
+
+# Robotics engineer mode: prototype navigation against repeatable, noisy sensors
+# without needing a full Gazebo/Isaac stack for early algorithm smoke tests.
+robotics_overlay: true
+obstacles:
+  - "460x220x160x90"
+  - "820x520x130x220"
+  - "1280x260x240x120"
+  - "1460x720x180x180"
+range_sensor:
+  rays: 41
+  fov_degrees: 180
+  max_range: 420
+  noise_stddev: 2.5
+  dropout_rate: 0.03
+  random_seed: 42

--- a/include/auto_vehicle.h
+++ b/include/auto_vehicle.h
@@ -2,10 +2,15 @@
 #define AUTO_VEHICLE_H
 
 #include <cmath>
+#include <cstdint>
+#include <string>
 #include "olcPixelGameEngine.h"
 #include "logger.h"
 #include "vehicle.h"
 #include "utils.h"
+#include "robotics_scenario.h"
+
+#include <vector>
 
 namespace autonomous_driving
 {
@@ -18,6 +23,9 @@ struct InitialConfig{
     int32_t height; /**< Height of the vehicle. */
     float_t xPosition; /**< X-coordinate of the initial position of the vehicle. */
     float_t yPosition; /**< Y-coordinate of the initial position of the vehicle. */
+    std::vector<RectangleObstacle> obstacles; /**< Scenario obstacles for robotics navigation testing. */
+    RangeSensorConfig rangeSensor; /**< Configurable 2D range sensor noise/dropout model. */
+    bool showRoboticsOverlay = true; /**< Draw range rays, obstacles, and debugging HUD. */
 };
 
 /**
@@ -136,6 +144,18 @@ private:
      * @endcode
      */
     logger::Logger data_log;
+
+    std::vector<RangeReading> last_scan;
+
+    /**
+     * @brief Draws robotics debugging overlays such as range rays and obstacles.
+     */
+    void draw_robotics_overlay();
+
+    /**
+     * @brief Returns the simulated sensor origin at the vehicle center.
+     */
+    Point2D get_sensor_origin() const;
 
 public:
     AutonomousVehicle(const autonomous_driving::InitialConfig& gameConfig);

--- a/include/robotics_scenario.h
+++ b/include/robotics_scenario.h
@@ -1,0 +1,153 @@
+#ifndef ROBOTICS_SCENARIO_H
+#define ROBOTICS_SCENARIO_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace autonomous_driving
+{
+
+struct Point2D {
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+struct RectangleObstacle {
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+};
+
+struct RangeSensorConfig {
+    int rays = 31;
+    float fieldOfViewDegrees = 180.0f;
+    float maxRange = 350.0f;
+    float noiseStdDev = 0.0f;
+    float dropoutRate = 0.0f;
+    std::uint32_t randomSeed = 7u;
+};
+
+struct RangeReading {
+    float rayAngleRadians = 0.0f;
+    float idealRange = 0.0f;
+    float measuredRange = 0.0f;
+    bool hit = false;
+    bool droppedOut = false;
+};
+
+constexpr float kPi = 3.14159265358979323846f;
+
+inline float degreesToRadians(float degrees) {
+    return degrees * kPi / 180.0f;
+}
+
+inline float clampFloat(float value, float low, float high) {
+    return std::max(low, std::min(value, high));
+}
+
+inline bool containsPoint(const RectangleObstacle& obstacle, Point2D point) {
+    return point.x >= obstacle.x && point.x <= obstacle.x + obstacle.width &&
+           point.y >= obstacle.y && point.y <= obstacle.y + obstacle.height;
+}
+
+inline bool rayIntersectsObstacle(
+    Point2D origin,
+    float angleRadians,
+    const RectangleObstacle& obstacle,
+    float maxRange,
+    float& hitDistance
+) {
+    const float dx = std::cos(angleRadians);
+    const float dy = std::sin(angleRadians);
+    float tMin = 0.0f;
+    float tMax = maxRange;
+
+    const auto updateInterval = [&](float rayOrigin, float rayDirection, float minBound, float maxBound,
+                                    float& currentMin, float& currentMax) -> bool {
+        constexpr float kEpsilon = 1e-6f;
+        if (std::fabs(rayDirection) < kEpsilon) {
+            return rayOrigin >= minBound && rayOrigin <= maxBound;
+        }
+
+        float t1 = (minBound - rayOrigin) / rayDirection;
+        float t2 = (maxBound - rayOrigin) / rayDirection;
+        if (t1 > t2) {
+            std::swap(t1, t2);
+        }
+
+        currentMin = std::max(currentMin, t1);
+        currentMax = std::min(currentMax, t2);
+        return currentMin <= currentMax;
+    };
+
+    const bool intersectsX = updateInterval(origin.x, dx, obstacle.x, obstacle.x + obstacle.width, tMin, tMax);
+    const bool intersectsY = updateInterval(origin.y, dy, obstacle.y, obstacle.y + obstacle.height, tMin, tMax);
+
+    if (!intersectsX || !intersectsY || tMax < 0.0f || tMin > maxRange) {
+        return false;
+    }
+
+    hitDistance = clampFloat(tMin < 0.0f ? tMax : tMin, 0.0f, maxRange);
+    return true;
+}
+
+inline float nearestObstacleDistance(
+    Point2D origin,
+    float angleRadians,
+    const std::vector<RectangleObstacle>& obstacles,
+    float maxRange
+) {
+    float nearest = maxRange;
+    for (const auto& obstacle : obstacles) {
+        float candidate = maxRange;
+        if (rayIntersectsObstacle(origin, angleRadians, obstacle, maxRange, candidate)) {
+            nearest = std::min(nearest, candidate);
+        }
+    }
+    return nearest;
+}
+
+inline std::vector<RangeReading> simulateRangeScan(
+    Point2D origin,
+    float headingRadians,
+    const std::vector<RectangleObstacle>& obstacles,
+    const RangeSensorConfig& config
+) {
+    const int rayCount = std::max(1, config.rays);
+    const float maxRange = std::max(0.0f, config.maxRange);
+    const float halfFov = degreesToRadians(config.fieldOfViewDegrees) * 0.5f;
+    const float step = rayCount == 1 ? 0.0f : (halfFov * 2.0f) / static_cast<float>(rayCount - 1);
+    const float dropoutRate = clampFloat(config.dropoutRate, 0.0f, 1.0f);
+
+    std::mt19937 rng(config.randomSeed);
+    std::normal_distribution<float> noise(0.0f, std::max(0.0f, config.noiseStdDev));
+    std::uniform_real_distribution<float> dropout(0.0f, 1.0f);
+
+    std::vector<RangeReading> readings;
+    readings.reserve(static_cast<std::size_t>(rayCount));
+
+    for (int i = 0; i < rayCount; ++i) {
+        const float rayAngle = headingRadians - halfFov + step * static_cast<float>(i);
+        const float idealRange = nearestObstacleDistance(origin, rayAngle, obstacles, maxRange);
+        const bool hit = idealRange < maxRange;
+        const bool droppedOut = dropoutRate > 0.0f && dropout(rng) < dropoutRate;
+        float measuredRange = maxRange;
+
+        if (!droppedOut) {
+            measuredRange = clampFloat(idealRange + noise(rng), 0.0f, maxRange);
+        }
+
+        readings.push_back({rayAngle, idealRange, measuredRange, hit, droppedOut});
+    }
+
+    return readings;
+}
+
+} // namespace autonomous_driving
+
+#endif // ROBOTICS_SCENARIO_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,27 +3,57 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace autonomous_driving {
 
 template <typename T>
+bool extractDelimitedValues(const std::string& text, char delimiter, std::vector<T>& values) {
+    values.clear();
+    std::stringstream stream(text);
+    std::string token;
+
+    while (std::getline(stream, token, delimiter)) {
+        if (token.empty()) {
+            return false;
+        }
+
+        std::stringstream tokenStream(token);
+        T value{};
+        if (!(tokenStream >> value)) {
+            values.clear();
+            return false;
+        }
+
+        values.push_back(value);
+    }
+
+    return !values.empty();
+}
+
+template <typename T>
 bool extractWidthHeight(const std::string& window_size, T& width, T& height) {
-    size_t xPos = window_size.find('x');
-    if (xPos == std::string::npos || xPos >= window_size.length()) {
+    std::vector<T> values;
+    if (!extractDelimitedValues<T>(window_size, 'x', values) || values.size() != 2) {
         return false;
     }
 
-    std::stringstream first(window_size.substr(0, xPos));
-    std::stringstream second(window_size.substr(xPos + 1));
+    width = values[0];
+    height = values[1];
+    return true;
+}
 
-    T w{};
-    T h{};
-    if (!(first >> w) || !(second >> h)) {
+template <typename T>
+bool extractRectangle(const std::string& rectangle, T& x, T& y, T& width, T& height) {
+    std::vector<T> values;
+    if (!extractDelimitedValues<T>(rectangle, 'x', values) || values.size() != 4) {
         return false;
     }
 
-    width = w;
-    height = h;
+    x = values[0];
+    y = values[1];
+    width = values[2];
+    height = values[3];
     return true;
 }
 

--- a/src/auto_vehicle.cpp
+++ b/src/auto_vehicle.cpp
@@ -3,6 +3,13 @@
 #include "utils.h"
 #include "yaml-cpp/yaml.h"
 
+#include <algorithm>
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+
 ////////////////////////////////////////////////////////:- Autonomous Vehicle Class -:////////////////////////////////////////////////////////
 autonomous_driving::AutonomousVehicle::AutonomousVehicle(const autonomous_driving::InitialConfig& gameConfig) {
     sAppName = "Autonomous Driving";
@@ -21,6 +28,9 @@ bool autonomous_driving::AutonomousVehicle::OnUserCreate() {
     max_vel = 500;
 
     data_log.log(logger::LogLevel::INFO, "Car Loaded. Car started....");
+    data_log.log(logger::LogLevel::INFO, "Robotics scenario loaded with " +
+                 std::to_string(gameConfig.obstacles.size()) + " obstacle(s) and " +
+                 std::to_string(std::max(1, gameConfig.rangeSensor.rays)) + " range rays.");
     
     // Car Image loading
     gpuCarRender = new olc::Decal(new olc::Sprite(this->gameConfig.CarPngPath));
@@ -58,8 +68,19 @@ bool autonomous_driving::AutonomousVehicle::OnUserUpdate(float fElapsedTime) {
 
     universal_boundaries(); // Set universal boundaries keep vehicle on the Screen
 
+    last_scan = simulateRangeScan(
+        get_sensor_origin(),
+        angle - kPi / 2.0f,
+        gameConfig.obstacles,
+        gameConfig.rangeSensor
+    );
+
     data_log.log(logger::LogLevel::INFO, "Velocity: " + std::to_string(velocity));
     
+    if (gameConfig.showRoboticsOverlay) {
+        draw_robotics_overlay();
+    }
+
     DrawRotatedDecal(position, gpuCarRender, angle, center_of_gravity);
     return true;
 }
@@ -85,6 +106,54 @@ void autonomous_driving::AutonomousVehicle::move_backward(float fElapsedTime) {
 void autonomous_driving::AutonomousVehicle::rotate_car(bool left, bool right) {
     if (left) angle += rotational_velocity;
     if (right) angle -= rotational_velocity; 
+}
+
+autonomous_driving::Point2D autonomous_driving::AutonomousVehicle::get_sensor_origin() const {
+    return {position.x, position.y};
+}
+
+void autonomous_driving::AutonomousVehicle::draw_robotics_overlay() {
+    for (const auto& obstacle : gameConfig.obstacles) {
+        FillRect(
+            static_cast<int32_t>(obstacle.x),
+            static_cast<int32_t>(obstacle.y),
+            static_cast<int32_t>(obstacle.width),
+            static_cast<int32_t>(obstacle.height),
+            olc::Pixel(70, 70, 70)
+        );
+        DrawRect(
+            static_cast<int32_t>(obstacle.x),
+            static_cast<int32_t>(obstacle.y),
+            static_cast<int32_t>(obstacle.width),
+            static_cast<int32_t>(obstacle.height),
+            olc::RED
+        );
+    }
+
+    const Point2D sensorOrigin = get_sensor_origin();
+    int hits = 0;
+    int dropouts = 0;
+    for (const auto& reading : last_scan) {
+        if (reading.hit) {
+            ++hits;
+        }
+        if (reading.droppedOut) {
+            ++dropouts;
+        }
+
+        const float range = reading.measuredRange;
+        const int endX = static_cast<int>(sensorOrigin.x + std::cos(reading.rayAngleRadians) * range);
+        const int endY = static_cast<int>(sensorOrigin.y + std::sin(reading.rayAngleRadians) * range);
+        const olc::Pixel color = reading.droppedOut ? olc::DARK_GREY : (reading.hit ? olc::RED : olc::BLUE);
+        DrawLine(static_cast<int>(sensorOrigin.x), static_cast<int>(sensorOrigin.y), endX, endY, color);
+        FillCircle(endX, endY, reading.hit && !reading.droppedOut ? 3 : 1, color);
+    }
+
+    std::ostringstream hud;
+    hud << "Range sensor: " << last_scan.size() << " rays | hits " << hits
+        << " | dropouts " << dropouts << " | noise σ " << std::fixed << std::setprecision(1)
+        << gameConfig.rangeSensor.noiseStdDev << " px";
+    DrawString(10, 10, hud.str(), olc::BLACK, 2);
 }
 
 void autonomous_driving::AutonomousVehicle::universal_boundaries() {
@@ -117,10 +186,57 @@ void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig
     if (!extractWidthHeight<float_t>(config["initial_position"].as<std::string>(), gameConfig.xPosition, gameConfig.yPosition)){
         std::cerr << "Cannot Extract Position" << std::endl;
     }
+
+    if (config["robotics_overlay"]) {
+        gameConfig.showRoboticsOverlay = config["robotics_overlay"].as<bool>();
+    }
+
+    if (config["obstacles"]) {
+        for (const auto& obstacleNode : config["obstacles"]) {
+            RectangleObstacle obstacle;
+            if (extractRectangle<float>(
+                    obstacleNode.as<std::string>(),
+                    obstacle.x,
+                    obstacle.y,
+                    obstacle.width,
+                    obstacle.height)) {
+                gameConfig.obstacles.push_back(obstacle);
+            } else {
+                std::cerr << "Cannot Extract Obstacle: " << obstacleNode.as<std::string>() << std::endl;
+            }
+        }
+    }
+
+    if (config["range_sensor"]) {
+        const YAML::Node sensor = config["range_sensor"];
+        if (sensor["rays"]) {
+            gameConfig.rangeSensor.rays = sensor["rays"].as<int>();
+        }
+        if (sensor["fov_degrees"]) {
+            gameConfig.rangeSensor.fieldOfViewDegrees = sensor["fov_degrees"].as<float>();
+        }
+        if (sensor["max_range"]) {
+            gameConfig.rangeSensor.maxRange = sensor["max_range"].as<float>();
+        }
+        if (sensor["noise_stddev"]) {
+            gameConfig.rangeSensor.noiseStdDev = sensor["noise_stddev"].as<float>();
+        }
+        if (sensor["dropout_rate"]) {
+            gameConfig.rangeSensor.dropoutRate = sensor["dropout_rate"].as<float>();
+        }
+        if (sensor["random_seed"]) {
+            gameConfig.rangeSensor.randomSeed = sensor["random_seed"].as<std::uint32_t>();
+        }
+    }
     
     std::cout << "[INFO]: PNG Loaded from " << gameConfig.CarPngPath << std::endl;
     std::printf("[INFO]: Window Size is %dx%d \n", gameConfig.width, gameConfig.height);
     std::printf("[INFO]: Initial position is %fx%f \n", gameConfig.xPosition, gameConfig.yPosition);
+    std::printf("[INFO]: Robotics scenario has %zu obstacle(s), %d rays, %.1f px max range, %.2f dropout rate \n",
+                gameConfig.obstacles.size(),
+                std::max(1, gameConfig.rangeSensor.rays),
+                gameConfig.rangeSensor.maxRange,
+                clampFloat(gameConfig.rangeSensor.dropoutRate, 0.0f, 1.0f));
 }
 
 
@@ -140,7 +256,7 @@ int main(int argc, char* argv[]){
     // Load Game configurations
     autonomous_driving::getYAMLData(path, gameConfig);
 
-    std::unique_ptr new_game = std::make_unique<autonomous_driving::AutonomousVehicle>(gameConfig);
+    auto new_game = std::make_unique<autonomous_driving::AutonomousVehicle>(gameConfig);
     if (new_game->Construct(gameConfig.width, gameConfig.height, 1, 1, false, true)){
         new_game->Start();
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_executable(parse_tests parse_tests.cpp)
 
 add_test(NAME parse_tests COMMAND parse_tests)
+
+add_executable(robotics_scenario_tests robotics_scenario_tests.cpp)
+add_test(NAME robotics_scenario_tests COMMAND robotics_scenario_tests)

--- a/tests/parse_tests.cpp
+++ b/tests/parse_tests.cpp
@@ -18,5 +18,16 @@ int main() {
     ok = autonomous_driving::extractWidthHeight<int>("1920-1080", badW, badH);
     assert(!ok);
 
+    float x = 0.f, y = 0.f, rectW = 0.f, rectH = 0.f;
+    ok = autonomous_driving::extractRectangle<float>("10x20x30x40", x, y, rectW, rectH);
+    assert(ok);
+    assert(std::fabs(x - 10.f) < 1e-6f);
+    assert(std::fabs(y - 20.f) < 1e-6f);
+    assert(std::fabs(rectW - 30.f) < 1e-6f);
+    assert(std::fabs(rectH - 40.f) < 1e-6f);
+
+    ok = autonomous_driving::extractRectangle<float>("10x20x30", x, y, rectW, rectH);
+    assert(!ok);
+
     return 0;
 }

--- a/tests/robotics_scenario_tests.cpp
+++ b/tests/robotics_scenario_tests.cpp
@@ -1,0 +1,43 @@
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include "robotics_scenario.h"
+
+int main() {
+    using namespace autonomous_driving;
+
+    const RectangleObstacle obstacle{10.0f, -5.0f, 10.0f, 10.0f};
+    float hitDistance = 0.0f;
+    bool hit = rayIntersectsObstacle({0.0f, 0.0f}, 0.0f, obstacle, 100.0f, hitDistance);
+    assert(hit);
+    assert(std::fabs(hitDistance - 10.0f) < 1e-5f);
+
+    const std::vector<RectangleObstacle> obstacles{obstacle, {30.0f, -5.0f, 10.0f, 10.0f}};
+    const float nearest = nearestObstacleDistance({0.0f, 0.0f}, 0.0f, obstacles, 100.0f);
+    assert(std::fabs(nearest - 10.0f) < 1e-5f);
+
+    RangeSensorConfig config;
+    config.rays = 3;
+    config.fieldOfViewDegrees = 0.0f;
+    config.maxRange = 100.0f;
+    config.noiseStdDev = 0.0f;
+    config.dropoutRate = 0.0f;
+    auto readings = simulateRangeScan({0.0f, 0.0f}, 0.0f, obstacles, config);
+    assert(readings.size() == 3);
+    for (const auto& reading : readings) {
+        assert(reading.hit);
+        assert(!reading.droppedOut);
+        assert(std::fabs(reading.idealRange - 10.0f) < 1e-5f);
+        assert(std::fabs(reading.measuredRange - 10.0f) < 1e-5f);
+    }
+
+    config.dropoutRate = 1.0f;
+    readings = simulateRangeScan({0.0f, 0.0f}, 0.0f, obstacles, config);
+    for (const auto& reading : readings) {
+        assert(reading.droppedOut);
+        assert(std::fabs(reading.measuredRange - config.maxRange) < 1e-5f);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Robotics engineers need a fast, repeatable smoke-test sandbox for navigation/perception that exposes sensor noise and dropout without heavy simulators or hardware-in-the-loop; the change targets that gap. 
- The project can add value as an early-stage testbed for obstacle-avoidance assumptions and deterministic reproduction of sensor failure cases. 
- Keep scope explicit: this is lightweight 2D tooling for early validation and not a full-fidelity replacement for Gazebo, Isaac Sim, MuJoCo, ROS, or HIL testing. 

### Description
- Add `include/robotics_scenario.h` implementing rectangular obstacles, ray/rectangle intersection, nearest-obstacle distance, and a seeded range-scan simulator with FOV, ray count, Gaussian noise, and dropout. 
- Extend configuration and runtime to support obstacles and a configurable `range_sensor` (YAML keys added to `configs/initializeGame.yaml`) and integrate the simulated scan into the game loop with a visual overlay (`draw_robotics_overlay`) and HUD. 
- Generalize parsing utilities in `include/utils.h` with `extractDelimitedValues` and add `extractRectangle` to parse obstacle strings; update `tests/parse_tests.cpp` accordingly. 
- Add `tests/robotics_scenario_tests.cpp` validating intersection, nearest-obstacle, deterministic noise/dropout behavior, and update `tests/CMakeLists.txt`; update `README.md` to document the feature and its intended scope. 
- Make `CMakeLists.txt` resilient to partial checkouts by skipping building the `autonomous_car` executable with a clear warning if `libraries/olcPixelGameEngine/olcPixelGameEngine.h` is missing, while still building and running unit tests. 

### Testing
- Ran `cmake -S . -B build && cmake --build build` and executed `ctest --test-dir build --output-on-failure`; both registered tests passed but CMake emitted a warning and skipped the GUI executable when the olcPGE header was absent. 
- Ran the unit tests compiled directly with `g++ -std=c++17 -Iinclude tests/parse_tests.cpp` and `g++ -std=c++17 -Iinclude tests/robotics_scenario_tests.cpp`; both test binaries executed and passed. 
- Performed a header-only syntax check and local compile smoke checks; no test failures were observed.
