### PR TITLE
Add 3D simulator preview foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoSIM — Autonomous Driving Simulator
 
-A 2D car simulator built with [olcPixelGameEngine](https://github.com/OneLoneCoder/olcPixelGameEngine). Drive a car around the screen using the arrow keys. Configuration (window size, starting position, car sprite) is loaded from a YAML file.
+A 2D autonomous driving simulator with an optional lightweight 3D preview, built with [olcPixelGameEngine](https://github.com/OneLoneCoder/olcPixelGameEngine). Drive a car around the screen using the arrow keys. Configuration (window size, starting position, car sprite, scenario obstacles, sensors, and 3D preview camera) is loaded from YAML files so users can author their own scenarios without recompiling.
 
 ![Demo Screenshot](assets/screenshot.png)
 <!-- Replace with an actual screenshot of the simulator running -->
@@ -20,6 +20,9 @@ Robotics engineers repeatedly report that simulation is useful for reducing slow
 - Built-in logger with INFO / WARNING / ERROR levels
 - Robotics scenario overlay with configurable rectangular obstacles
 - Deterministic 2D range sensor simulator with field-of-view, ray count, max range, Gaussian noise, dropout rate, and seed controls
+- Lightweight 3D preview mode with AutoSIM-owned projection math, wireframe boxes, and deterministic 3D range scans
+- User-authored YAML scenarios for 2D rectangles, 3D boxes, camera settings, and sensor behavior
+- In-window GUI/status overlay with discoverable runtime controls
 
 ---
 
@@ -66,24 +69,43 @@ If no config path is given, it defaults to `../configs/initializeGame.yaml`.
 
 ---
 
+## 3D Rendering Support
+
+The upstream olcPixelGameEngine project is suitable as AutoSIM's lightweight window/input/pixel-rendering layer, and its README lists a "3D Software renderer" as an extension example. However, the olcPGE wiki also states that the base engine intentionally does not provide typical game resources such as collision detection, vector math, or asset management. AutoSIM therefore treats olcPGE as the renderer/input shell and owns the 3D simulator math, scenario schema, sensors, and validation code in this repository. See `docs/3d_simulator_plan.md` for the verification notes and roadmap.
+
 ## Configuration
 
-Edit `configs/initializeGame.yaml` to change the startup settings:
+Edit `configs/initializeGame.yaml` or pass your own YAML file to change the startup settings:
 
 ```yaml
+scenario_name: "warehouse-smoke-test"
+simulator_mode: "2d"               # "2d" or "3d_preview"; F2 toggles at runtime
 car_png: "../assets/car.png"       # Path to the car sprite
 window_size: "1980x1080"           # Window width x height
 initial_position: "100x100"        # Starting X x Y position of the car
 
-robotics_overlay: true              # Draw obstacles, range rays, and HUD
-obstacles:                          # x/y/width/height rectangles in pixels
+robotics_overlay: true              # F1 toggles obstacles/range rays
+gui_overlay: true                   # TAB toggles the status/help panel
+
+obstacles:                          # 2D x/y/width/height rectangles in pixels
   - "460x220x160x90"
   - "820x520x130x220"
+
+obstacles_3d:                       # 3D x/y/z/width/depth/height boxes
+  - "-420x0x360x160x90x110"
+  - "-40x0x620x130x220x160"
+
+camera_3d:
+  position: "0x180x-520"
+  yaw_degrees: 0
+  pitch_degrees: -12
+  focal_length: 520
+
 range_sensor:
   rays: 41                          # Number of simulated range beams
   fov_degrees: 180                  # Sensor field of view
-  max_range: 420                    # Maximum beam distance in pixels
-  noise_stddev: 2.5                 # Gaussian range noise in pixels
+  max_range: 420                    # Maximum beam distance in pixels/units
+  noise_stddev: 2.5                 # Gaussian range noise
   dropout_rate: 0.03                # Probability a reading returns max range
   random_seed: 42                   # Repeatable noise/dropout sequence
 ```
@@ -98,6 +120,9 @@ range_sensor:
 | ↓ Down     | Reverse         |
 | ← Left     | Rotate left     |
 | → Right    | Rotate right    |
+| F1         | Toggle robotics/range overlay |
+| F2         | Toggle 2D / 3D preview mode |
+| Tab        | Toggle GUI/status panel |
 
 ---
 
@@ -107,9 +132,10 @@ The robotics overlay is designed for early navigation and perception smoke tests
 
 1. Add obstacle rectangles to `configs/initializeGame.yaml`.
 2. Tune the range sensor model to mimic imperfect low-cost lidar, sonar, IR, or depth preprocessing.
-3. Use the deterministic `random_seed` to reproduce a failure case, then increase `noise_stddev` or `dropout_rate` to check robustness.
+3. Add `obstacles_3d` boxes and set `simulator_mode: "3d_preview"` when you want a projected 3D smoke-test view.
+4. Use the deterministic `random_seed` to reproduce a failure case, then increase `noise_stddev` or `dropout_rate` to check robustness.
 
-This feature intentionally solves a small pain point: quick, repeatable testing of obstacle-avoidance assumptions before spending time in a heavier simulator or on physical hardware. It does **not** claim physical fidelity, wheel slip, 3D contact dynamics, ROS integration, or camera-realistic synthetic data.
+This feature intentionally solves a small pain point: quick, repeatable testing of obstacle-avoidance assumptions before spending time in a heavier simulator or on physical hardware. The 3D preview is a reliable visualization and range-sensor smoke-test layer, but it does **not** claim physical fidelity, wheel slip, 3D contact dynamics, ROS integration, textured model loading, or camera-realistic synthetic data.
 
 ---
 
@@ -122,6 +148,7 @@ AutoSIM_olcPixel/
 ├── include/                 # Header files
 │   ├── auto_vehicle.h       # Main vehicle class
 │   ├── logger.h             # Logger
+│   ├── simulator_3d.h       # 3D projection, box, and range sensor helpers
 │   ├── vehicle.h            # Base vehicle class
 │   └── utils.h              # Utility functions
 ├── src/                     # Source files
@@ -130,6 +157,7 @@ AutoSIM_olcPixel/
 │   └── vehicle.cpp          # Base vehicle implementation
 ├── libraries/
 │   └── olcPixelGameEngine/  # olcPGE submodule
+├── docs/                    # Design notes and roadmap
 ├── tests/                   # Unit tests
 └── CMakeLists.txt
 ```

--- a/configs/initializeGame.yaml
+++ b/configs/initializeGame.yaml
@@ -1,15 +1,35 @@
+scenario_name: "warehouse-smoke-test"
+simulator_mode: "2d"                 # "2d" or "3d_preview"; F2 toggles at runtime
 car_png: "../assets/car.png"
 window_size: "1980x1080"
 initial_position: "100x100"
 
 # Robotics engineer mode: prototype navigation against repeatable, noisy sensors
 # without needing a full Gazebo/Isaac stack for early algorithm smoke tests.
-robotics_overlay: true
+robotics_overlay: true                 # F1 toggles range rays/obstacles at runtime
+gui_overlay: true                      # TAB toggles the in-window help/status panel
+
+# User-authored 2D scenario obstacles: "x y width height" encoded as x-delimited values.
 obstacles:
   - "460x220x160x90"
   - "820x520x130x220"
   - "1280x260x240x120"
   - "1460x720x180x180"
+
+# User-authored 3D preview boxes: "x y z width depth height" in simulator units.
+# x/z place the footprint on the ground plane; y is the floor elevation.
+obstacles_3d:
+  - "-420x0x360x160x90x110"
+  - "-40x0x620x130x220x160"
+  - "420x0x420x240x120x140"
+  - "650x0x860x180x180x180"
+
+camera_3d:
+  position: "0x180x-520"
+  yaw_degrees: 0
+  pitch_degrees: -12
+  focal_length: 520
+
 range_sensor:
   rays: 41
   fov_degrees: 180

--- a/docs/3d_simulator_plan.md
+++ b/docs/3d_simulator_plan.md
@@ -1,0 +1,47 @@
+# AutoSIM 3D Simulator Plan
+
+## olcPixelGameEngine 3D support verification
+
+olcPixelGameEngine is a lightweight pixel/game framework, not a full 3D simulation engine. The upstream project describes the engine as a cross-platform pixel drawing and UI framework, and lists a "3D Software renderer" as an example extension. Its wiki also says the base engine does not provide typical game resources such as asset loading, collision detection, or vector mathematics, and that users are expected to provide that functionality. In practice this means AutoSIM can use olcPGE to draw a 3D projection, but reliable robotics simulation needs AutoSIM-owned math, scenario schema, sensors, collision, and validation layers.
+
+Current repository status: the `libraries/olcPixelGameEngine` submodule directory exists, but `olcPixelGameEngine.h` is not present in this checkout. CMake already skips the runnable simulator executable until the submodule is initialized.
+
+## Implementation strategy
+
+1. Keep olcPGE as the window/input/pixel-rendering layer.
+2. Add AutoSIM-owned 3D math and sensor primitives that can be unit-tested without a graphical dependency.
+3. Render the first 3D simulator milestone as a wireframe preview using olcPGE line primitives.
+4. Let users author scenarios in YAML with stable 2D and 3D obstacle schemas.
+5. Add a minimal in-window GUI overlay for discoverable controls before adopting a larger GUI toolkit.
+
+## What is implemented now
+
+- `simulator_mode: "2d" | "3d_preview"` selects the mode; F2 toggles at runtime.
+- `obstacles_3d` accepts user-authored boxes as `"x×y×z×width×depth×height"`-style x-delimited values without recompiling.
+- `camera_3d` sets the preview camera position, yaw, pitch, and focal length.
+- 3D range scans use deterministic noise/dropout behavior through the existing `range_sensor` configuration.
+- TAB toggles the in-window GUI panel; F1 toggles robotics/range overlays.
+
+## Recommended roadmap
+
+### Milestone 1: reliable 3D preview
+
+- Continue validating 3D projection, ray/box intersection, and YAML parsing with unit tests.
+- Add schema documentation and sample scenario files for common warehouses, parking lots, and intersections.
+- Add camera controls for pan/orbit/zoom.
+
+### Milestone 2: scenario authoring UX
+
+- Add mouse-based obstacle placement/editing.
+- Save edited scenarios back to YAML.
+- Validate scenario files before launch and report actionable errors.
+
+### Milestone 3: robotics fidelity
+
+- Add vehicle footprint collision against 3D boxes.
+- Add vertical field-of-view for multi-layer lidar/depth-like scans.
+- Add sensor recording/replay files for regression tests.
+
+### Milestone 4: full 3D backend decision
+
+If the simulator must support textured 3D models, lighting, cameras, complex physics, or larger worlds, keep the olcPGE preview as a quick smoke-test mode and add a dedicated 3D backend such as OpenGL/OGRE/Filament or integrate with Gazebo/Isaac/MuJoCo for high-fidelity validation.

--- a/include/auto_vehicle.h
+++ b/include/auto_vehicle.h
@@ -9,6 +9,7 @@
 #include "vehicle.h"
 #include "utils.h"
 #include "robotics_scenario.h"
+#include "simulator_3d.h"
 
 #include <vector>
 
@@ -17,15 +18,25 @@ namespace autonomous_driving
 /**
  * @brief Structure representing the initial configuration of a vehicle.
  */
+enum class SimulatorMode {
+    Planar2D,
+    Preview3D
+};
+
 struct InitialConfig{
+    std::string scenarioName = "default"; /**< Human-friendly scenario name for user-authored scenarios. */
+    SimulatorMode simulatorMode = SimulatorMode::Planar2D; /**< 2D mode or lightweight 3D preview mode. */
     std::string CarPngPath; /**< Path to the car PNG file. */
     int32_t width; /**< Width of the vehicle. */
     int32_t height; /**< Height of the vehicle. */
     float_t xPosition; /**< X-coordinate of the initial position of the vehicle. */
     float_t yPosition; /**< Y-coordinate of the initial position of the vehicle. */
     std::vector<RectangleObstacle> obstacles; /**< Scenario obstacles for robotics navigation testing. */
-    RangeSensorConfig rangeSensor; /**< Configurable 2D range sensor noise/dropout model. */
+    std::vector<BoxObstacle3D> obstacles3D; /**< 3D scenario boxes for preview rendering and 3D range scans. */
+    Camera3D camera3D; /**< Camera used by the 3D preview renderer. */
+    RangeSensorConfig rangeSensor; /**< Configurable 2D/3D range sensor noise/dropout model. */
     bool showRoboticsOverlay = true; /**< Draw range rays, obstacles, and debugging HUD. */
+    bool showGuiOverlay = true; /**< Draw controls, scenario details, and mode information. */
 };
 
 /**
@@ -39,6 +50,9 @@ struct InitialConfig{
  * @param gameConfig The InitialConfig object to be populated with the YAML data.
  */
 void getYAMLData(const std::string& yaml_path, InitialConfig& gameConfig);
+
+SimulatorMode parseSimulatorMode(const std::string& text);
+std::string simulatorModeToString(SimulatorMode mode);
 
 /**
  * @brief Extracts the width and height from a given window size string.
@@ -146,6 +160,7 @@ private:
     logger::Logger data_log;
 
     std::vector<RangeReading> last_scan;
+    std::vector<RangeReading3D> last_scan_3d;
 
     /**
      * @brief Draws robotics debugging overlays such as range rays and obstacles.
@@ -153,9 +168,24 @@ private:
     void draw_robotics_overlay();
 
     /**
+     * @brief Draws a lightweight wireframe 3D preview using olcPGE 2D primitives.
+     */
+    void draw_3d_preview();
+
+    /**
+     * @brief Draws in-window GUI help and scenario status.
+     */
+    void draw_gui_overlay();
+
+    /**
      * @brief Returns the simulated sensor origin at the vehicle center.
      */
     Point2D get_sensor_origin() const;
+
+    /**
+     * @brief Returns the simulated 3D sensor origin using screen position as ground-plane coordinates.
+     */
+    Vec3 get_sensor_origin_3d() const;
 
 public:
     AutonomousVehicle(const autonomous_driving::InitialConfig& gameConfig);

--- a/include/simulator_3d.h
+++ b/include/simulator_3d.h
@@ -1,0 +1,232 @@
+#ifndef SIMULATOR_3D_H
+#define SIMULATOR_3D_H
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "robotics_scenario.h"
+
+namespace autonomous_driving
+{
+
+struct Vec2 {
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+struct Vec3 {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+struct Camera3D {
+    Vec3 position{0.0f, 120.0f, -420.0f};
+    float yawRadians = 0.0f;
+    float pitchRadians = degreesToRadians(-12.0f);
+    float focalLength = 520.0f;
+    float nearPlane = 1.0f;
+};
+
+struct BoxObstacle3D {
+    Vec3 center{0.0f, 0.0f, 0.0f};
+    Vec3 size{1.0f, 1.0f, 1.0f};
+};
+
+struct ProjectedPoint {
+    Vec2 screen;
+    bool visible = false;
+    float depth = 0.0f;
+};
+
+struct RangeReading3D {
+    float yawRadians = 0.0f;
+    float pitchRadians = 0.0f;
+    float idealRange = 0.0f;
+    float measuredRange = 0.0f;
+    bool hit = false;
+    bool droppedOut = false;
+};
+
+inline Vec3 add(Vec3 left, Vec3 right) {
+    return {left.x + right.x, left.y + right.y, left.z + right.z};
+}
+
+inline Vec3 subtract(Vec3 left, Vec3 right) {
+    return {left.x - right.x, left.y - right.y, left.z - right.z};
+}
+
+inline Vec3 multiply(Vec3 value, float scalar) {
+    return {value.x * scalar, value.y * scalar, value.z * scalar};
+}
+
+inline float dot(Vec3 left, Vec3 right) {
+    return left.x * right.x + left.y * right.y + left.z * right.z;
+}
+
+inline float length(Vec3 value) {
+    return std::sqrt(dot(value, value));
+}
+
+inline Vec3 normalize(Vec3 value) {
+    const float magnitude = length(value);
+    if (magnitude <= 1e-6f) {
+        return {0.0f, 0.0f, 1.0f};
+    }
+
+    return multiply(value, 1.0f / magnitude);
+}
+
+inline Vec3 directionFromAngles(float yawRadians, float pitchRadians) {
+    const float cosPitch = std::cos(pitchRadians);
+    return normalize({std::sin(yawRadians) * cosPitch, std::sin(pitchRadians), std::cos(yawRadians) * cosPitch});
+}
+
+inline Vec3 rotateWorldToCamera(Vec3 point, const Camera3D& camera) {
+    Vec3 translated = subtract(point, camera.position);
+
+    const float cosYaw = std::cos(-camera.yawRadians);
+    const float sinYaw = std::sin(-camera.yawRadians);
+    Vec3 yawed{
+        translated.x * cosYaw - translated.z * sinYaw,
+        translated.y,
+        translated.x * sinYaw + translated.z * cosYaw
+    };
+
+    const float cosPitch = std::cos(-camera.pitchRadians);
+    const float sinPitch = std::sin(-camera.pitchRadians);
+    return {
+        yawed.x,
+        yawed.y * cosPitch - yawed.z * sinPitch,
+        yawed.y * sinPitch + yawed.z * cosPitch
+    };
+}
+
+inline ProjectedPoint projectPoint(Vec3 point, const Camera3D& camera, float screenWidth, float screenHeight) {
+    const Vec3 cameraSpace = rotateWorldToCamera(point, camera);
+    if (cameraSpace.z <= camera.nearPlane) {
+        return {{0.0f, 0.0f}, false, cameraSpace.z};
+    }
+
+    return {{
+        screenWidth * 0.5f + (cameraSpace.x * camera.focalLength) / cameraSpace.z,
+        screenHeight * 0.5f - (cameraSpace.y * camera.focalLength) / cameraSpace.z
+    }, true, cameraSpace.z};
+}
+
+inline std::array<Vec3, 8> boxCorners(const BoxObstacle3D& box) {
+    const Vec3 half = multiply(box.size, 0.5f);
+    return {{
+        {box.center.x - half.x, box.center.y - half.y, box.center.z - half.z},
+        {box.center.x + half.x, box.center.y - half.y, box.center.z - half.z},
+        {box.center.x + half.x, box.center.y + half.y, box.center.z - half.z},
+        {box.center.x - half.x, box.center.y + half.y, box.center.z - half.z},
+        {box.center.x - half.x, box.center.y - half.y, box.center.z + half.z},
+        {box.center.x + half.x, box.center.y - half.y, box.center.z + half.z},
+        {box.center.x + half.x, box.center.y + half.y, box.center.z + half.z},
+        {box.center.x - half.x, box.center.y + half.y, box.center.z + half.z}
+    }};
+}
+
+inline const std::array<std::array<int, 2>, 12>& boxEdges() {
+    static const std::array<std::array<int, 2>, 12> edges{{
+        {{0, 1}}, {{1, 2}}, {{2, 3}}, {{3, 0}},
+        {{4, 5}}, {{5, 6}}, {{6, 7}}, {{7, 4}},
+        {{0, 4}}, {{1, 5}}, {{2, 6}}, {{3, 7}}
+    }};
+    return edges;
+}
+
+inline bool rayIntersectsBox(Vec3 origin, Vec3 direction, const BoxObstacle3D& box, float maxRange, float& hitDistance) {
+    const Vec3 half = multiply(box.size, 0.5f);
+    const Vec3 minimum = subtract(box.center, half);
+    const Vec3 maximum = add(box.center, half);
+    float tMin = 0.0f;
+    float tMax = maxRange;
+
+    const auto updateInterval = [&](float rayOrigin, float rayDirection, float minBound, float maxBound,
+                                    float& currentMin, float& currentMax) -> bool {
+        constexpr float kEpsilon = 1e-6f;
+        if (std::fabs(rayDirection) < kEpsilon) {
+            return rayOrigin >= minBound && rayOrigin <= maxBound;
+        }
+
+        float t1 = (minBound - rayOrigin) / rayDirection;
+        float t2 = (maxBound - rayOrigin) / rayDirection;
+        if (t1 > t2) {
+            std::swap(t1, t2);
+        }
+
+        currentMin = std::max(currentMin, t1);
+        currentMax = std::min(currentMax, t2);
+        return currentMin <= currentMax;
+    };
+
+    if (!updateInterval(origin.x, direction.x, minimum.x, maximum.x, tMin, tMax) ||
+        !updateInterval(origin.y, direction.y, minimum.y, maximum.y, tMin, tMax) ||
+        !updateInterval(origin.z, direction.z, minimum.z, maximum.z, tMin, tMax) ||
+        tMax < 0.0f || tMin > maxRange) {
+        return false;
+    }
+
+    hitDistance = clampFloat(tMin < 0.0f ? tMax : tMin, 0.0f, maxRange);
+    return true;
+}
+
+inline float nearestBoxDistance(Vec3 origin, Vec3 direction, const std::vector<BoxObstacle3D>& boxes, float maxRange) {
+    float nearest = maxRange;
+    for (const auto& box : boxes) {
+        float candidate = maxRange;
+        if (rayIntersectsBox(origin, direction, box, maxRange, candidate)) {
+            nearest = std::min(nearest, candidate);
+        }
+    }
+    return nearest;
+}
+
+inline std::vector<RangeReading3D> simulateRangeScan3D(
+    Vec3 origin,
+    float yawRadians,
+    float pitchRadians,
+    const std::vector<BoxObstacle3D>& boxes,
+    const RangeSensorConfig& config
+) {
+    const int rayCount = std::max(1, config.rays);
+    const float maxRange = std::max(0.0f, config.maxRange);
+    const float halfFov = degreesToRadians(config.fieldOfViewDegrees) * 0.5f;
+    const float step = rayCount == 1 ? 0.0f : (halfFov * 2.0f) / static_cast<float>(rayCount - 1);
+    const float dropoutRate = clampFloat(config.dropoutRate, 0.0f, 1.0f);
+
+    std::mt19937 rng(config.randomSeed);
+    std::normal_distribution<float> noise(0.0f, std::max(0.0f, config.noiseStdDev));
+    std::uniform_real_distribution<float> dropout(0.0f, 1.0f);
+
+    std::vector<RangeReading3D> readings;
+    readings.reserve(static_cast<std::size_t>(rayCount));
+
+    for (int i = 0; i < rayCount; ++i) {
+        const float rayYaw = yawRadians - halfFov + step * static_cast<float>(i);
+        const Vec3 direction = directionFromAngles(rayYaw, pitchRadians);
+        const float idealRange = nearestBoxDistance(origin, direction, boxes, maxRange);
+        const bool hit = idealRange < maxRange;
+        const bool droppedOut = dropoutRate > 0.0f && dropout(rng) < dropoutRate;
+        float measuredRange = maxRange;
+
+        if (!droppedOut) {
+            measuredRange = clampFloat(idealRange + noise(rng), 0.0f, maxRange);
+        }
+
+        readings.push_back({rayYaw, pitchRadians, idealRange, measuredRange, hit, droppedOut});
+    }
+
+    return readings;
+}
+
+} // namespace autonomous_driving
+
+#endif // SIMULATOR_3D_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -57,6 +57,22 @@ bool extractRectangle(const std::string& rectangle, T& x, T& y, T& width, T& hei
     return true;
 }
 
+template <typename T>
+bool extractBox(const std::string& box, T& x, T& y, T& z, T& width, T& depth, T& height) {
+    std::vector<T> values;
+    if (!extractDelimitedValues<T>(box, 'x', values) || values.size() != 6) {
+        return false;
+    }
+
+    x = values[0];
+    y = values[1];
+    z = values[2];
+    width = values[3];
+    depth = values[4];
+    height = values[5];
+    return true;
+}
+
 } // namespace autonomous_driving
 
 #endif // UTILS_H

--- a/src/auto_vehicle.cpp
+++ b/src/auto_vehicle.cpp
@@ -9,10 +9,11 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <string>
 
 ////////////////////////////////////////////////////////:- Autonomous Vehicle Class -:////////////////////////////////////////////////////////
 autonomous_driving::AutonomousVehicle::AutonomousVehicle(const autonomous_driving::InitialConfig& gameConfig) {
-    sAppName = "Autonomous Driving";
+    sAppName = "AutoSIM — Autonomous Driving";
     this->gameConfig = gameConfig;
 }
 
@@ -28,8 +29,10 @@ bool autonomous_driving::AutonomousVehicle::OnUserCreate() {
     max_vel = 500;
 
     data_log.log(logger::LogLevel::INFO, "Car Loaded. Car started....");
-    data_log.log(logger::LogLevel::INFO, "Robotics scenario loaded with " +
-                 std::to_string(gameConfig.obstacles.size()) + " obstacle(s) and " +
+    data_log.log(logger::LogLevel::INFO, "Scenario '" + gameConfig.scenarioName + "' loaded in " +
+                 simulatorModeToString(gameConfig.simulatorMode) + " mode with " +
+                 std::to_string(gameConfig.obstacles.size()) + " 2D obstacle(s), " +
+                 std::to_string(gameConfig.obstacles3D.size()) + " 3D obstacle(s), and " +
                  std::to_string(std::max(1, gameConfig.rangeSensor.rays)) + " range rays.");
     
     // Car Image loading
@@ -68,20 +71,49 @@ bool autonomous_driving::AutonomousVehicle::OnUserUpdate(float fElapsedTime) {
 
     universal_boundaries(); // Set universal boundaries keep vehicle on the Screen
 
-    last_scan = simulateRangeScan(
-        get_sensor_origin(),
-        angle - kPi / 2.0f,
-        gameConfig.obstacles,
-        gameConfig.rangeSensor
-    );
-
-    data_log.log(logger::LogLevel::INFO, "Velocity: " + std::to_string(velocity));
-    
-    if (gameConfig.showRoboticsOverlay) {
-        draw_robotics_overlay();
+    if (GetKey(olc::Key::TAB).bPressed) {
+        gameConfig.showGuiOverlay = !gameConfig.showGuiOverlay;
     }
 
-    DrawRotatedDecal(position, gpuCarRender, angle, center_of_gravity);
+    if (GetKey(olc::Key::F1).bPressed) {
+        gameConfig.showRoboticsOverlay = !gameConfig.showRoboticsOverlay;
+    }
+
+    if (GetKey(olc::Key::F2).bPressed) {
+        gameConfig.simulatorMode = gameConfig.simulatorMode == SimulatorMode::Planar2D
+            ? SimulatorMode::Preview3D
+            : SimulatorMode::Planar2D;
+    }
+
+    if (gameConfig.simulatorMode == SimulatorMode::Preview3D) {
+        last_scan_3d = simulateRangeScan3D(
+            get_sensor_origin_3d(),
+            kPi - angle,
+            0.0f,
+            gameConfig.obstacles3D,
+            gameConfig.rangeSensor
+        );
+        draw_3d_preview();
+    } else {
+        last_scan = simulateRangeScan(
+            get_sensor_origin(),
+            angle - kPi / 2.0f,
+            gameConfig.obstacles,
+            gameConfig.rangeSensor
+        );
+
+        if (gameConfig.showRoboticsOverlay) {
+            draw_robotics_overlay();
+        }
+
+        DrawRotatedDecal(position, gpuCarRender, angle, center_of_gravity);
+    }
+
+    data_log.log(logger::LogLevel::INFO, "Velocity: " + std::to_string(velocity));
+
+    if (gameConfig.showGuiOverlay) {
+        draw_gui_overlay();
+    }
     return true;
 }
 
@@ -110,6 +142,10 @@ void autonomous_driving::AutonomousVehicle::rotate_car(bool left, bool right) {
 
 autonomous_driving::Point2D autonomous_driving::AutonomousVehicle::get_sensor_origin() const {
     return {position.x, position.y};
+}
+
+autonomous_driving::Vec3 autonomous_driving::AutonomousVehicle::get_sensor_origin_3d() const {
+    return {position.x - ScreenWidth() * 0.5f, 12.0f, position.y};
 }
 
 void autonomous_driving::AutonomousVehicle::draw_robotics_overlay() {
@@ -156,6 +192,86 @@ void autonomous_driving::AutonomousVehicle::draw_robotics_overlay() {
     DrawString(10, 10, hud.str(), olc::BLACK, 2);
 }
 
+
+void autonomous_driving::AutonomousVehicle::draw_3d_preview() {
+    const auto project = [&](Vec3 point) {
+        return projectPoint(point, gameConfig.camera3D, static_cast<float>(ScreenWidth()), static_cast<float>(ScreenHeight()));
+    };
+
+    const float gridExtent = 1200.0f;
+    const float gridStep = 100.0f;
+    for (float value = -gridExtent; value <= gridExtent; value += gridStep) {
+        const ProjectedPoint a = project({-gridExtent, 0.0f, value});
+        const ProjectedPoint b = project({gridExtent, 0.0f, value});
+        const ProjectedPoint c = project({value, 0.0f, -100.0f});
+        const ProjectedPoint d = project({value, 0.0f, gridExtent});
+        if (a.visible && b.visible) {
+            DrawLine(static_cast<int>(a.screen.x), static_cast<int>(a.screen.y), static_cast<int>(b.screen.x), static_cast<int>(b.screen.y), olc::VERY_DARK_GREY);
+        }
+        if (c.visible && d.visible) {
+            DrawLine(static_cast<int>(c.screen.x), static_cast<int>(c.screen.y), static_cast<int>(d.screen.x), static_cast<int>(d.screen.y), olc::VERY_DARK_GREY);
+        }
+    }
+
+    for (const auto& box : gameConfig.obstacles3D) {
+        const auto corners = boxCorners(box);
+        for (const auto& edge : boxEdges()) {
+            const ProjectedPoint start = project(corners[static_cast<std::size_t>(edge[0])]);
+            const ProjectedPoint end = project(corners[static_cast<std::size_t>(edge[1])]);
+            if (start.visible && end.visible) {
+                DrawLine(static_cast<int>(start.screen.x), static_cast<int>(start.screen.y),
+                         static_cast<int>(end.screen.x), static_cast<int>(end.screen.y), olc::DARK_RED);
+            }
+        }
+    }
+
+    const Vec3 vehicleOrigin = get_sensor_origin_3d();
+    const ProjectedPoint vehicle = project(vehicleOrigin);
+    if (vehicle.visible) {
+        FillCircle(static_cast<int>(vehicle.screen.x), static_cast<int>(vehicle.screen.y), 5, olc::GREEN);
+    }
+
+    if (gameConfig.showRoboticsOverlay) {
+        for (const auto& reading : last_scan_3d) {
+            const Vec3 direction = directionFromAngles(reading.yawRadians, reading.pitchRadians);
+            const Vec3 endPoint = add(vehicleOrigin, multiply(direction, reading.measuredRange));
+            const ProjectedPoint end = project(endPoint);
+            if (vehicle.visible && end.visible) {
+                const olc::Pixel color = reading.droppedOut ? olc::DARK_GREY : (reading.hit ? olc::RED : olc::BLUE);
+                DrawLine(static_cast<int>(vehicle.screen.x), static_cast<int>(vehicle.screen.y),
+                         static_cast<int>(end.screen.x), static_cast<int>(end.screen.y), color);
+            }
+        }
+    }
+}
+
+void autonomous_driving::AutonomousVehicle::draw_gui_overlay() {
+    int hits = 0;
+    int dropouts = 0;
+    if (gameConfig.simulatorMode == SimulatorMode::Preview3D) {
+        for (const auto& reading : last_scan_3d) {
+            if (reading.hit) { ++hits; }
+            if (reading.droppedOut) { ++dropouts; }
+        }
+    } else {
+        for (const auto& reading : last_scan) {
+            if (reading.hit) { ++hits; }
+            if (reading.droppedOut) { ++dropouts; }
+        }
+    }
+
+    FillRect(8, ScreenHeight() - 86, 690, 76, olc::Pixel(245, 245, 245));
+    DrawRect(8, ScreenHeight() - 86, 690, 76, olc::DARK_GREY);
+
+    std::ostringstream hud;
+    hud << "Scenario: " << gameConfig.scenarioName
+        << " | Mode: " << simulatorModeToString(gameConfig.simulatorMode)
+        << " | Sensor hits " << hits << " dropouts " << dropouts;
+    DrawString(16, ScreenHeight() - 78, hud.str(), olc::BLACK, 1);
+    DrawString(16, ScreenHeight() - 58, "Controls: Arrow keys drive | F1 sensor overlay | F2 2D/3D preview | TAB GUI", olc::BLACK, 1);
+    DrawString(16, ScreenHeight() - 38, "3D preview is wireframe projection on olcPGE; use authored YAML boxes for scenarios.", olc::DARK_BLUE, 1);
+}
+
 void autonomous_driving::AutonomousVehicle::universal_boundaries() {
     if (static_cast<int>(position.x) >= ScreenWidth()) {
         position.x = 0;
@@ -175,8 +291,32 @@ void autonomous_driving::AutonomousVehicle::universal_boundaries() {
 }
 
 ////////////////////////////////////////////////////////////:- Global functions -:////////////////////////////////////////////////////////////
+autonomous_driving::SimulatorMode autonomous_driving::parseSimulatorMode(const std::string& text) {
+    if (text == "3d" || text == "3D" || text == "preview_3d" || text == "3d_preview") {
+        return SimulatorMode::Preview3D;
+    }
+
+    return SimulatorMode::Planar2D;
+}
+
+std::string autonomous_driving::simulatorModeToString(SimulatorMode mode) {
+    switch (mode) {
+        case SimulatorMode::Preview3D:
+            return "3d_preview";
+        case SimulatorMode::Planar2D:
+        default:
+            return "2d";
+    }
+}
+
 void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig& gameConfig){
     YAML::Node config = YAML::LoadFile(yaml_path);
+    if (config["scenario_name"]) {
+        gameConfig.scenarioName = config["scenario_name"].as<std::string>();
+    }
+    if (config["simulator_mode"]) {
+        gameConfig.simulatorMode = parseSimulatorMode(config["simulator_mode"].as<std::string>());
+    }
     gameConfig.CarPngPath = config["car_png"].as<std::string>();
 
     if (!extractWidthHeight<int32_t>(config["window_size"].as<std::string>(), gameConfig.width, gameConfig.height)){
@@ -189,6 +329,10 @@ void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig
 
     if (config["robotics_overlay"]) {
         gameConfig.showRoboticsOverlay = config["robotics_overlay"].as<bool>();
+    }
+
+    if (config["gui_overlay"]) {
+        gameConfig.showGuiOverlay = config["gui_overlay"].as<bool>();
     }
 
     if (config["obstacles"]) {
@@ -204,6 +348,47 @@ void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig
             } else {
                 std::cerr << "Cannot Extract Obstacle: " << obstacleNode.as<std::string>() << std::endl;
             }
+        }
+    }
+
+    if (config["obstacles_3d"]) {
+        for (const auto& obstacleNode : config["obstacles_3d"]) {
+            float x = 0.0f;
+            float y = 0.0f;
+            float z = 0.0f;
+            float width = 0.0f;
+            float depth = 0.0f;
+            float height = 0.0f;
+            if (extractBox<float>(obstacleNode.as<std::string>(), x, y, z, width, depth, height)) {
+                gameConfig.obstacles3D.push_back({{x, y + height * 0.5f, z}, {width, height, depth}});
+            } else {
+                std::cerr << "Cannot Extract 3D Obstacle: " << obstacleNode.as<std::string>() << std::endl;
+            }
+        }
+    }
+
+    if (config["camera_3d"]) {
+        const YAML::Node camera = config["camera_3d"];
+        if (camera["position"]) {
+            float x = 0.0f;
+            float y = 0.0f;
+            float z = 0.0f;
+            std::vector<float> values;
+            if (extractDelimitedValues<float>(camera["position"].as<std::string>(), 'x', values) && values.size() == 3) {
+                x = values[0]; y = values[1]; z = values[2];
+                gameConfig.camera3D.position = {x, y, z};
+            } else {
+                std::cerr << "Cannot Extract 3D Camera Position: " << camera["position"].as<std::string>() << std::endl;
+            }
+        }
+        if (camera["yaw_degrees"]) {
+            gameConfig.camera3D.yawRadians = degreesToRadians(camera["yaw_degrees"].as<float>());
+        }
+        if (camera["pitch_degrees"]) {
+            gameConfig.camera3D.pitchRadians = degreesToRadians(camera["pitch_degrees"].as<float>());
+        }
+        if (camera["focal_length"]) {
+            gameConfig.camera3D.focalLength = camera["focal_length"].as<float>();
         }
     }
 
@@ -232,8 +417,11 @@ void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig
     std::cout << "[INFO]: PNG Loaded from " << gameConfig.CarPngPath << std::endl;
     std::printf("[INFO]: Window Size is %dx%d \n", gameConfig.width, gameConfig.height);
     std::printf("[INFO]: Initial position is %fx%f \n", gameConfig.xPosition, gameConfig.yPosition);
-    std::printf("[INFO]: Robotics scenario has %zu obstacle(s), %d rays, %.1f px max range, %.2f dropout rate \n",
+    std::printf("[INFO]: Scenario '%s' uses mode %s with %zu 2D obstacle(s), %zu 3D obstacle(s), %d rays, %.1f px max range, %.2f dropout rate \n",
+                gameConfig.scenarioName.c_str(),
+                simulatorModeToString(gameConfig.simulatorMode).c_str(),
                 gameConfig.obstacles.size(),
+                gameConfig.obstacles3D.size(),
                 std::max(1, gameConfig.rangeSensor.rays),
                 gameConfig.rangeSensor.maxRange,
                 clampFloat(gameConfig.rangeSensor.dropoutRate, 0.0f, 1.0f));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,3 +4,6 @@ add_test(NAME parse_tests COMMAND parse_tests)
 
 add_executable(robotics_scenario_tests robotics_scenario_tests.cpp)
 add_test(NAME robotics_scenario_tests COMMAND robotics_scenario_tests)
+
+add_executable(simulator_3d_tests simulator_3d_tests.cpp)
+add_test(NAME simulator_3d_tests COMMAND simulator_3d_tests)

--- a/tests/parse_tests.cpp
+++ b/tests/parse_tests.cpp
@@ -29,5 +29,18 @@ int main() {
     ok = autonomous_driving::extractRectangle<float>("10x20x30", x, y, rectW, rectH);
     assert(!ok);
 
+    float z = 0.f, boxW = 0.f, boxD = 0.f, boxH = 0.f;
+    ok = autonomous_driving::extractBox<float>("10x20x30x40x50x60", x, y, z, boxW, boxD, boxH);
+    assert(ok);
+    assert(std::fabs(x - 10.f) < 1e-6f);
+    assert(std::fabs(y - 20.f) < 1e-6f);
+    assert(std::fabs(z - 30.f) < 1e-6f);
+    assert(std::fabs(boxW - 40.f) < 1e-6f);
+    assert(std::fabs(boxD - 50.f) < 1e-6f);
+    assert(std::fabs(boxH - 60.f) < 1e-6f);
+
+    ok = autonomous_driving::extractBox<float>("10x20x30x40x50", x, y, z, boxW, boxD, boxH);
+    assert(!ok);
+
     return 0;
 }

--- a/tests/simulator_3d_tests.cpp
+++ b/tests/simulator_3d_tests.cpp
@@ -1,0 +1,65 @@
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include "simulator_3d.h"
+#include "utils.h"
+
+int main() {
+    using namespace autonomous_driving;
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    float width = 0.0f;
+    float depth = 0.0f;
+    float height = 0.0f;
+    bool ok = extractBox<float>("10x20x30x40x50x60", x, y, z, width, depth, height);
+    assert(ok);
+    assert(std::fabs(x - 10.0f) < 1e-6f);
+    assert(std::fabs(y - 20.0f) < 1e-6f);
+    assert(std::fabs(z - 30.0f) < 1e-6f);
+    assert(std::fabs(width - 40.0f) < 1e-6f);
+    assert(std::fabs(depth - 50.0f) < 1e-6f);
+    assert(std::fabs(height - 60.0f) < 1e-6f);
+
+    ok = extractBox<float>("10x20x30x40x50", x, y, z, width, depth, height);
+    assert(!ok);
+
+    const BoxObstacle3D box{{0.0f, 0.0f, 20.0f}, {10.0f, 10.0f, 10.0f}};
+    float hitDistance = 0.0f;
+    const bool hit = rayIntersectsBox({0.0f, 0.0f, 0.0f}, directionFromAngles(0.0f, 0.0f), box, 100.0f, hitDistance);
+    assert(hit);
+    assert(std::fabs(hitDistance - 15.0f) < 1e-5f);
+
+    const std::vector<BoxObstacle3D> boxes{box, {{0.0f, 0.0f, 50.0f}, {10.0f, 10.0f, 10.0f}}};
+    const float nearest = nearestBoxDistance({0.0f, 0.0f, 0.0f}, directionFromAngles(0.0f, 0.0f), boxes, 100.0f);
+    assert(std::fabs(nearest - 15.0f) < 1e-5f);
+
+    RangeSensorConfig config;
+    config.rays = 3;
+    config.fieldOfViewDegrees = 0.0f;
+    config.maxRange = 100.0f;
+    config.noiseStdDev = 0.0f;
+    config.dropoutRate = 0.0f;
+    auto readings = simulateRangeScan3D({0.0f, 0.0f, 0.0f}, 0.0f, 0.0f, boxes, config);
+    assert(readings.size() == 3);
+    for (const auto& reading : readings) {
+        assert(reading.hit);
+        assert(!reading.droppedOut);
+        assert(std::fabs(reading.idealRange - 15.0f) < 1e-5f);
+        assert(std::fabs(reading.measuredRange - 15.0f) < 1e-5f);
+    }
+
+    Camera3D camera;
+    camera.position = {0.0f, 0.0f, 0.0f};
+    camera.pitchRadians = 0.0f;
+    camera.yawRadians = 0.0f;
+    camera.focalLength = 100.0f;
+    const ProjectedPoint projected = projectPoint({0.0f, 0.0f, 10.0f}, camera, 800.0f, 600.0f);
+    assert(projected.visible);
+    assert(std::fabs(projected.screen.x - 400.0f) < 1e-5f);
+    assert(std::fabs(projected.screen.y - 300.0f) < 1e-5f);
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight 3D preview mode and user-authored 3D scenarios so developers can smoke-test perception/navigation in a projected 3D view without adopting a full 3D engine.    
- Verify olcPixelGameEngine's role as a window/input/pixel-rendering layer and keep all 3D math, sensor models, scenario schema, and validation under AutoSIM control for reliability and unit testing.    
- Add a simple discoverable GUI and runtime controls so users can toggle overlays and switch between 2D/3D modes without recompiling.

### Description

- Added `include/simulator_3d.h` which implements lightweight 3D primitives (Vec3/Camera3D/BoxObstacle3D), projection (`projectPoint`), box corner/edge helpers, ray/box intersection, nearest-box queries and a deterministic 3D range-scan helper (`simulateRangeScan3D`).    
- Added `extractBox` to `include/utils.h` for parsing `"x×y×z×width×depth×height"`-style YAML entries.    
- Extended configuration and runtime code: `include/auto_vehicle.h` and `src/auto_vehicle.cpp` now support `scenarioName`, `SimulatorMode` (`2d` / `3d_preview`), `obstacles3D`, `camera3D`, `showGuiOverlay`, runtime keys (`TAB` for GUI, `F1` for sensor overlay, `F2` to toggle 2D/3D), `last_scan_3d`, and the rendering helpers `draw_3d_preview()` and `draw_gui_overlay()` that draw a wireframe preview and HUD using olcPGE 2D primitives.    
- YAML and docs: `configs/initializeGame.yaml` supports `simulator_mode`, `obstacles_3d`, and `camera_3d`; `README.md` and new `docs/3d_simulator_plan.md` document the design decision and roadmap.    
- Tests and build: added `tests/simulator_3d_tests.cpp`, updated `tests/parse_tests.cpp`, and added the test target to `tests/CMakeLists.txt` so projection, box parsing, ray/box intersection and 3D scan behavior are unit-tested.

### Testing

- Built the project and ran the automated test suite with `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`, and all tests passed (3/3).    
- Also ran the individual test executables (`simulator_3d_tests`, `parse_tests`, `robotics_scenario_tests`) which completed successfully.    
- The graphical `autonomous_car` executable was skipped by CMake because `libraries/olcPixelGameEngine/olcPixelGameEngine.h` is not present in this checkout (CMake emits a warning to initialize the submodule), but that does not affect the new unit-tested 3D math and parsing helpers.