### PR TITLE
Fix car movement and steering direction logic

### DIFF
--- a/include/auto_vehicle.h
+++ b/include/auto_vehicle.h
@@ -105,9 +105,19 @@ private:
     float velocity;
   
     /**
-     * @brief The rotational velocity of the vehicle.
+     * @brief The rotational velocity of the vehicle in radians per second at maximum speed.
      */
     float rotational_velocity;
+
+    /**
+     * @brief Speeds at or below this value are considered stopped for movement and steering.
+     */
+    static constexpr float stationary_speed_threshold = 0.01f;
+
+    /**
+     * @brief Minimum steering responsiveness once the vehicle is moving.
+     */
+    static constexpr float minimum_steering_scale = 0.25f;
 
     /**
      * Represents a 2D vector with integer components.
@@ -230,12 +240,21 @@ public:
     void move_backward(float fElapsedTime);
 
     /**
-     * Rotates the car in the specified direction.
+     * Applies drag when no throttle input is held.
+     *
+     * @param fElapsedTime The elapsed time since the last frame.
+     */
+    void apply_drag(float fElapsedTime);
+
+    /**
+     * Rotates the car in the specified direction only while the vehicle is moving.
+     * Steering is reversed while backing up so turns follow the current travel direction.
      *
      * @param left Specifies whether the car should rotate left.
      * @param right Specifies whether the car should rotate right.
+     * @param fElapsedTime The elapsed time since the last frame.
      */
-    void rotate_car(bool left, bool right);
+    void rotate_car(bool left, bool right, float fElapsedTime);
 
     /**
      * @brief Sets the universal boundaries for the vehicle.

--- a/src/auto_vehicle.cpp
+++ b/src/auto_vehicle.cpp
@@ -25,7 +25,7 @@ bool autonomous_driving::AutonomousVehicle::OnUserCreate() {
     acceleration = 1.0f;
     angle = 0.0f;
     velocity = 0;
-    rotational_velocity = 0.1;
+    rotational_velocity = 3.0f;
     max_vel = 500;
 
     data_log.log(logger::LogLevel::INFO, "Car Loaded. Car started....");
@@ -47,26 +47,22 @@ bool autonomous_driving::AutonomousVehicle::OnUserUpdate(float fElapsedTime) {
     Clear(olc::WHITE);
 
     // Keyboard Events
-    if (GetKey(olc::Key::UP).bHeld) {
+    const bool accelerating = GetKey(olc::Key::UP).bHeld;
+    const bool reversing = GetKey(olc::Key::DOWN).bHeld;
+    const bool steeringLeft = GetKey(olc::Key::LEFT).bHeld;
+    const bool steeringRight = GetKey(olc::Key::RIGHT).bHeld;
+
+    if (accelerating) {
         move_forward(fElapsedTime);
-    } else if (GetKey(olc::Key::DOWN).bHeld) {
+    } else if (reversing) {
         move_backward(fElapsedTime);
-    }
-
-    if (GetKey(olc::Key::LEFT).bHeld) {
-        rotate_car(true, false);
-    } else if (GetKey(olc::Key::RIGHT).bHeld) {
-        rotate_car(false, true);
-    }
-
-    if (!GetKey(olc::Key::UP).bHeld && !GetKey(olc::Key::DOWN).bHeld) {
-        if (velocity < 0) {
-            velocity += 0.5;
-        }
-        if (velocity > 0) {
-            velocity -= 0.5;
-        }
+    } else {
+        apply_drag(fElapsedTime);
         move(fElapsedTime);
+    }
+
+    if (steeringLeft || steeringRight) {
+        rotate_car(steeringLeft, steeringRight, fElapsedTime);
     }
 
     universal_boundaries(); // Set universal boundaries keep vehicle on the Screen
@@ -118,11 +114,16 @@ bool autonomous_driving::AutonomousVehicle::OnUserUpdate(float fElapsedTime) {
 }
 
 void autonomous_driving::AutonomousVehicle::move(float fElapsedTime) {
-    float_t verticle = std::cos(angle) * velocity;
-    float_t horizontal = std::sin(angle) * velocity;
-    
-    position.y -= verticle * fElapsedTime;
-    position.x -= horizontal * fElapsedTime;
+    if (std::fabs(velocity) <= stationary_speed_threshold) {
+        velocity = 0.0f;
+        return;
+    }
+
+    const float_t forwardX = std::sin(angle);
+    const float_t forwardY = -std::cos(angle);
+
+    position.x += forwardX * velocity * fElapsedTime;
+    position.y += forwardY * velocity * fElapsedTime;
 }
 
 void autonomous_driving::AutonomousVehicle::move_forward(float fElapsedTime) {
@@ -135,9 +136,27 @@ void autonomous_driving::AutonomousVehicle::move_backward(float fElapsedTime) {
     move(fElapsedTime);
 }
 
-void autonomous_driving::AutonomousVehicle::rotate_car(bool left, bool right) {
-    if (left) angle += rotational_velocity;
-    if (right) angle -= rotational_velocity; 
+void autonomous_driving::AutonomousVehicle::apply_drag(float fElapsedTime) {
+    const float drag = acceleration * 30.0f * fElapsedTime;
+
+    if (std::fabs(velocity) <= drag) {
+        velocity = 0.0f;
+        return;
+    }
+
+    velocity += velocity > 0.0f ? -drag : drag;
+}
+
+void autonomous_driving::AutonomousVehicle::rotate_car(bool left, bool right, float fElapsedTime) {
+    if (std::fabs(velocity) <= stationary_speed_threshold || left == right) {
+        return;
+    }
+
+    const float steeringDirection = right ? 1.0f : -1.0f;
+    const float movementDirection = velocity > 0.0f ? 1.0f : -1.0f;
+    const float speedRatio = std::clamp(std::fabs(velocity) / max_vel, minimum_steering_scale, 1.0f);
+
+    angle += steeringDirection * movementDirection * rotational_velocity * speedRatio * fElapsedTime;
 }
 
 autonomous_driving::Point2D autonomous_driving::AutonomousVehicle::get_sensor_origin() const {


### PR DESCRIPTION
### Motivation
- The vehicle was rotating in place when stationary and steering while turning produced incorrect orientation changes because steering was applied independently of motion and the movement vector signs were inconsistent. 
- The intent is to make steering depend on actual travel direction, stop spurious rotation at near-zero speed, and have movement follow the visual heading.

### Description
- Separate input handling into explicit `accelerating`, `reversing`, `steeringLeft`, and `steeringRight` flags and only apply steering via a movement-aware rotation function (`rotate_car(bool left, bool right, float fElapsedTime)`).
- Replace the old position update with a consistent forward vector based on `angle` (`forwardX = sin(angle)`, `forwardY = -cos(angle)`) and update `position.x`/`position.y` using `velocity * fElapsedTime` in `move()`.
- Add `apply_drag(float fElapsedTime)` to decelerate smoothly and snap very small speeds to zero, add `stationary_speed_threshold` and `minimum_steering_scale` constants, and scale steering by speed so steering only affects the vehicle while moving and reverses direction when backing up.
- Adjust `rotational_velocity` to a more suitable value and update the header API and docs (`include/auto_vehicle.h` and `src/auto_vehicle.cpp`).

### Testing
- Built the project and ran the test suite with `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`, and all tests passed (3/3). 
- Re-ran `cmake --build build && ctest --test-dir build --output-on-failure` after edits and all tests again passed (3/3). 
- Note: CMake emitted a warning that `olcPixelGameEngine.h` was not found so the simulator executable was skipped, but the automated unit tests still completed successfully.
