### PR TITLE
Add third-person 3D vehicle preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Robotics engineers repeatedly report that simulation is useful for reducing slow
 - Built-in logger with INFO / WARNING / ERROR levels
 - Robotics scenario overlay with configurable rectangular obstacles
 - Deterministic 2D range sensor simulator with field-of-view, ray count, max range, Gaussian noise, dropout rate, and seed controls
-- Lightweight 3D preview mode with AutoSIM-owned projection math, wireframe boxes, and deterministic 3D range scans
+- Lightweight 3D preview mode with AutoSIM-owned projection math, wireframe boxes, a procedural 3D vehicle model, movable third-person follow camera, and deterministic 3D range scans
 - User-authored YAML scenarios for 2D rectangles, 3D boxes, camera settings, and sensor behavior
 - In-window GUI/status overlay with discoverable runtime controls
 
@@ -96,10 +96,28 @@ obstacles_3d:                       # 3D x/y/z/width/depth/height boxes
   - "-40x0x620x130x220x160"
 
 camera_3d:
-  position: "0x180x-520"
+  position: "0x180x-520"       # Focal/startup fallback; 3D mode follows the car
   yaw_degrees: 0
   pitch_degrees: -12
   focal_length: 520
+
+third_person_camera:
+  distance: 360                 # W/S zoom in/out
+  height: 145                   # Q/E raise/lower camera
+  orbit_degrees: 0              # A/D orbit around the vehicle; R resets
+  min_distance: 140
+  max_distance: 900
+  min_height: 45
+  max_height: 420
+
+vehicle_model_3d:                # local_x/local_y/local_z/width/depth/height parts
+  - "0x18x0x70x120x26"          # chassis
+  - "0x42x-8x46x58x28"         # cabin
+  - "-42x12x-38x16x24x24"      # rear-left wheel
+  - "42x12x-38x16x24x24"       # rear-right wheel
+  - "-42x12x38x16x24x24"       # front-left wheel
+  - "42x12x38x16x24x24"        # front-right wheel
+  - "0x28x72x30x18x16"         # front marker
 
 range_sensor:
   rays: 41                          # Number of simulated range beams
@@ -123,6 +141,10 @@ range_sensor:
 | F1         | Toggle robotics/range overlay |
 | F2         | Toggle 2D / 3D preview mode |
 | Tab        | Toggle GUI/status panel |
+| A / D      | Orbit the 3D third-person camera left/right |
+| W / S      | Zoom the 3D third-person camera in/out |
+| Q / E      | Raise/lower the 3D third-person camera |
+| R          | Reset the 3D third-person camera |
 
 ---
 
@@ -133,7 +155,8 @@ The robotics overlay is designed for early navigation and perception smoke tests
 1. Add obstacle rectangles to `configs/initializeGame.yaml`.
 2. Tune the range sensor model to mimic imperfect low-cost lidar, sonar, IR, or depth preprocessing.
 3. Add `obstacles_3d` boxes and set `simulator_mode: "3d_preview"` when you want a projected 3D smoke-test view.
-4. Use the deterministic `random_seed` to reproduce a failure case, then increase `noise_stddev` or `dropout_rate` to check robustness.
+4. Tune `third_person_camera` and `vehicle_model_3d` to inspect the procedural vehicle from a movable chase-camera view.
+5. Use the deterministic `random_seed` to reproduce a failure case, then increase `noise_stddev` or `dropout_rate` to check robustness.
 
 This feature intentionally solves a small pain point: quick, repeatable testing of obstacle-avoidance assumptions before spending time in a heavier simulator or on physical hardware. The 3D preview is a reliable visualization and range-sensor smoke-test layer, but it does **not** claim physical fidelity, wheel slip, 3D contact dynamics, ROS integration, textured model loading, or camera-realistic synthetic data.
 

--- a/configs/initializeGame.yaml
+++ b/configs/initializeGame.yaml
@@ -25,10 +25,30 @@ obstacles_3d:
   - "650x0x860x180x180x180"
 
 camera_3d:
-  position: "0x180x-520"
+  position: "0x180x-520"       # Used as startup/focal fallback; 3D mode follows the vehicle.
   yaw_degrees: 0
   pitch_degrees: -12
   focal_length: 520
+
+third_person_camera:
+  distance: 360                 # W/S zoom the follow camera in/out at runtime.
+  height: 145                   # Q/E raise/lower the follow camera.
+  orbit_degrees: 0              # A/D orbit around the vehicle; R resets to these values.
+  min_distance: 140
+  max_distance: 900
+  min_height: 45
+  max_height: 420
+
+# Procedural 3D vehicle model parts: "local_x local_y local_z width depth height"
+# encoded as x-delimited values and attached to the simulated vehicle pose.
+vehicle_model_3d:
+  - "0x18x0x70x120x26"          # chassis
+  - "0x42x-8x46x58x28"         # cabin
+  - "-42x12x-38x16x24x24"      # rear-left wheel
+  - "42x12x-38x16x24x24"       # rear-right wheel
+  - "-42x12x38x16x24x24"       # front-left wheel
+  - "42x12x38x16x24x24"        # front-right wheel
+  - "0x28x72x30x18x16"         # front marker
 
 range_sensor:
   rays: 41

--- a/include/auto_vehicle.h
+++ b/include/auto_vehicle.h
@@ -34,6 +34,8 @@ struct InitialConfig{
     std::vector<RectangleObstacle> obstacles; /**< Scenario obstacles for robotics navigation testing. */
     std::vector<BoxObstacle3D> obstacles3D; /**< 3D scenario boxes for preview rendering and 3D range scans. */
     Camera3D camera3D; /**< Camera used by the 3D preview renderer. */
+    ThirdPersonCameraConfig thirdPersonCamera; /**< Follow-camera orbit, zoom, and height settings for 3D mode. */
+    std::vector<VehicleModelPart3D> vehicleModel3D = defaultVehicleModel3D(); /**< Procedural 3D vehicle model parts. */
     RangeSensorConfig rangeSensor; /**< Configurable 2D/3D range sensor noise/dropout model. */
     bool showRoboticsOverlay = true; /**< Draw range rays, obstacles, and debugging HUD. */
     bool showGuiOverlay = true; /**< Draw controls, scenario details, and mode information. */
@@ -171,6 +173,7 @@ private:
 
     std::vector<RangeReading> last_scan;
     std::vector<RangeReading3D> last_scan_3d;
+    ThirdPersonCameraConfig activeThirdPersonCamera;
 
     /**
      * @brief Draws robotics debugging overlays such as range rays and obstacles.
@@ -181,6 +184,16 @@ private:
      * @brief Draws a lightweight wireframe 3D preview using olcPGE 2D primitives.
      */
     void draw_3d_preview();
+
+    /**
+     * @brief Draws the composed procedural 3D vehicle model.
+     */
+    void draw_vehicle_model_3d(const Camera3D& camera, Vec3 vehicleOrigin, float vehicleYawRadians);
+
+    /**
+     * @brief Applies 3D follow-camera orbit, zoom, and height controls.
+     */
+    void update_third_person_camera(float fElapsedTime);
 
     /**
      * @brief Draws in-window GUI help and scenario status.

--- a/include/simulator_3d.h
+++ b/include/simulator_3d.h
@@ -33,8 +33,23 @@ struct Camera3D {
     float nearPlane = 1.0f;
 };
 
+struct ThirdPersonCameraConfig {
+    float distance = 360.0f;
+    float height = 145.0f;
+    float orbitRadians = 0.0f;
+    float minDistance = 140.0f;
+    float maxDistance = 900.0f;
+    float minHeight = 45.0f;
+    float maxHeight = 420.0f;
+};
+
 struct BoxObstacle3D {
     Vec3 center{0.0f, 0.0f, 0.0f};
+    Vec3 size{1.0f, 1.0f, 1.0f};
+};
+
+struct VehicleModelPart3D {
+    Vec3 localCenter{0.0f, 0.0f, 0.0f};
     Vec3 size{1.0f, 1.0f, 1.0f};
 };
 
@@ -82,6 +97,16 @@ inline Vec3 normalize(Vec3 value) {
     return multiply(value, 1.0f / magnitude);
 }
 
+inline Vec3 rotateAroundY(Vec3 value, float yawRadians) {
+    const float cosYaw = std::cos(yawRadians);
+    const float sinYaw = std::sin(yawRadians);
+    return {
+        value.x * cosYaw + value.z * sinYaw,
+        value.y,
+        -value.x * sinYaw + value.z * cosYaw
+    };
+}
+
 inline Vec3 directionFromAngles(float yawRadians, float pitchRadians) {
     const float cosPitch = std::cos(pitchRadians);
     return normalize({std::sin(yawRadians) * cosPitch, std::sin(pitchRadians), std::cos(yawRadians) * cosPitch});
@@ -107,6 +132,23 @@ inline Vec3 rotateWorldToCamera(Vec3 point, const Camera3D& camera) {
     };
 }
 
+inline Camera3D makeThirdPersonCamera(Vec3 target, float vehicleYawRadians, ThirdPersonCameraConfig config) {
+    config.distance = clampFloat(config.distance, config.minDistance, config.maxDistance);
+    config.height = clampFloat(config.height, config.minHeight, config.maxHeight);
+
+    const float cameraYawAroundTarget = vehicleYawRadians + config.orbitRadians;
+    const Vec3 forward = directionFromAngles(cameraYawAroundTarget, 0.0f);
+    const Vec3 position = add(subtract(target, multiply(forward, config.distance)), {0.0f, config.height, 0.0f});
+    const Vec3 toTarget = subtract(target, position);
+    const float horizontal = std::sqrt(toTarget.x * toTarget.x + toTarget.z * toTarget.z);
+
+    Camera3D camera;
+    camera.position = position;
+    camera.yawRadians = std::atan2(toTarget.x, toTarget.z);
+    camera.pitchRadians = std::atan2(toTarget.y, horizontal);
+    return camera;
+}
+
 inline ProjectedPoint projectPoint(Vec3 point, const Camera3D& camera, float screenWidth, float screenHeight) {
     const Vec3 cameraSpace = rotateWorldToCamera(point, camera);
     if (cameraSpace.z <= camera.nearPlane) {
@@ -117,6 +159,26 @@ inline ProjectedPoint projectPoint(Vec3 point, const Camera3D& camera, float scr
         screenWidth * 0.5f + (cameraSpace.x * camera.focalLength) / cameraSpace.z,
         screenHeight * 0.5f - (cameraSpace.y * camera.focalLength) / cameraSpace.z
     }, true, cameraSpace.z};
+}
+
+inline std::array<Vec3, 8> orientedBoxCorners(const VehicleModelPart3D& part, Vec3 worldOrigin, float yawRadians) {
+    const Vec3 half = multiply(part.size, 0.5f);
+    const std::array<Vec3, 8> localCorners{{
+        {part.localCenter.x - half.x, part.localCenter.y - half.y, part.localCenter.z - half.z},
+        {part.localCenter.x + half.x, part.localCenter.y - half.y, part.localCenter.z - half.z},
+        {part.localCenter.x + half.x, part.localCenter.y + half.y, part.localCenter.z - half.z},
+        {part.localCenter.x - half.x, part.localCenter.y + half.y, part.localCenter.z - half.z},
+        {part.localCenter.x - half.x, part.localCenter.y - half.y, part.localCenter.z + half.z},
+        {part.localCenter.x + half.x, part.localCenter.y - half.y, part.localCenter.z + half.z},
+        {part.localCenter.x + half.x, part.localCenter.y + half.y, part.localCenter.z + half.z},
+        {part.localCenter.x - half.x, part.localCenter.y + half.y, part.localCenter.z + half.z}
+    }};
+
+    std::array<Vec3, 8> corners{};
+    for (std::size_t i = 0; i < localCorners.size(); ++i) {
+        corners[i] = add(worldOrigin, rotateAroundY(localCorners[i], yawRadians));
+    }
+    return corners;
 }
 
 inline std::array<Vec3, 8> boxCorners(const BoxObstacle3D& box) {
@@ -131,6 +193,18 @@ inline std::array<Vec3, 8> boxCorners(const BoxObstacle3D& box) {
         {box.center.x + half.x, box.center.y + half.y, box.center.z + half.z},
         {box.center.x - half.x, box.center.y + half.y, box.center.z + half.z}
     }};
+}
+
+inline std::vector<VehicleModelPart3D> defaultVehicleModel3D() {
+    return {
+        {{0.0f, 18.0f, 0.0f}, {70.0f, 26.0f, 120.0f}},
+        {{0.0f, 42.0f, -8.0f}, {46.0f, 28.0f, 58.0f}},
+        {{-42.0f, 12.0f, -38.0f}, {16.0f, 24.0f, 24.0f}},
+        {{42.0f, 12.0f, -38.0f}, {16.0f, 24.0f, 24.0f}},
+        {{-42.0f, 12.0f, 38.0f}, {16.0f, 24.0f, 24.0f}},
+        {{42.0f, 12.0f, 38.0f}, {16.0f, 24.0f, 24.0f}},
+        {{0.0f, 28.0f, 72.0f}, {30.0f, 16.0f, 18.0f}}
+    };
 }
 
 inline const std::array<std::array<int, 2>, 12>& boxEdges() {

--- a/src/auto_vehicle.cpp
+++ b/src/auto_vehicle.cpp
@@ -27,6 +27,7 @@ bool autonomous_driving::AutonomousVehicle::OnUserCreate() {
     velocity = 0;
     rotational_velocity = 3.0f;
     max_vel = 500;
+    activeThirdPersonCamera = gameConfig.thirdPersonCamera;
 
     data_log.log(logger::LogLevel::INFO, "Car Loaded. Car started....");
     data_log.log(logger::LogLevel::INFO, "Scenario '" + gameConfig.scenarioName + "' loaded in " +
@@ -82,6 +83,10 @@ bool autonomous_driving::AutonomousVehicle::OnUserUpdate(float fElapsedTime) {
     }
 
     if (gameConfig.simulatorMode == SimulatorMode::Preview3D) {
+        update_third_person_camera(fElapsedTime);
+        const float configuredFocalLength = gameConfig.camera3D.focalLength;
+        gameConfig.camera3D = makeThirdPersonCamera(get_sensor_origin_3d(), kPi - angle, activeThirdPersonCamera);
+        gameConfig.camera3D.focalLength = std::max(120.0f, configuredFocalLength);
         last_scan_3d = simulateRangeScan3D(
             get_sensor_origin_3d(),
             kPi - angle,
@@ -212,6 +217,68 @@ void autonomous_driving::AutonomousVehicle::draw_robotics_overlay() {
 }
 
 
+void autonomous_driving::AutonomousVehicle::update_third_person_camera(float fElapsedTime) {
+    const float orbitSpeed = 1.5f * fElapsedTime;
+    const float zoomSpeed = 320.0f * fElapsedTime;
+    const float heightSpeed = 220.0f * fElapsedTime;
+
+    if (GetKey(olc::Key::A).bHeld) {
+        activeThirdPersonCamera.orbitRadians -= orbitSpeed;
+    }
+    if (GetKey(olc::Key::D).bHeld) {
+        activeThirdPersonCamera.orbitRadians += orbitSpeed;
+    }
+    if (GetKey(olc::Key::W).bHeld) {
+        activeThirdPersonCamera.distance -= zoomSpeed;
+    }
+    if (GetKey(olc::Key::S).bHeld) {
+        activeThirdPersonCamera.distance += zoomSpeed;
+    }
+    if (GetKey(olc::Key::Q).bHeld) {
+        activeThirdPersonCamera.height += heightSpeed;
+    }
+    if (GetKey(olc::Key::E).bHeld) {
+        activeThirdPersonCamera.height -= heightSpeed;
+    }
+    if (GetKey(olc::Key::R).bPressed) {
+        activeThirdPersonCamera = gameConfig.thirdPersonCamera;
+    }
+
+    activeThirdPersonCamera.distance = clampFloat(
+        activeThirdPersonCamera.distance,
+        activeThirdPersonCamera.minDistance,
+        activeThirdPersonCamera.maxDistance
+    );
+    activeThirdPersonCamera.height = clampFloat(
+        activeThirdPersonCamera.height,
+        activeThirdPersonCamera.minHeight,
+        activeThirdPersonCamera.maxHeight
+    );
+}
+
+void autonomous_driving::AutonomousVehicle::draw_vehicle_model_3d(const Camera3D& camera, Vec3 vehicleOrigin, float vehicleYawRadians) {
+    const auto project = [&](Vec3 point) {
+        return projectPoint(point, camera, static_cast<float>(ScreenWidth()), static_cast<float>(ScreenHeight()));
+    };
+
+    const std::vector<olc::Pixel> partColors{
+        olc::DARK_GREEN, olc::GREEN, olc::BLACK, olc::BLACK, olc::BLACK, olc::BLACK, olc::YELLOW
+    };
+
+    for (std::size_t partIndex = 0; partIndex < gameConfig.vehicleModel3D.size(); ++partIndex) {
+        const auto corners = orientedBoxCorners(gameConfig.vehicleModel3D[partIndex], vehicleOrigin, vehicleYawRadians);
+        const olc::Pixel color = partColors[std::min(partIndex, partColors.size() - 1)];
+        for (const auto& edge : boxEdges()) {
+            const ProjectedPoint start = project(corners[static_cast<std::size_t>(edge[0])]);
+            const ProjectedPoint end = project(corners[static_cast<std::size_t>(edge[1])]);
+            if (start.visible && end.visible) {
+                DrawLine(static_cast<int>(start.screen.x), static_cast<int>(start.screen.y),
+                         static_cast<int>(end.screen.x), static_cast<int>(end.screen.y), color);
+            }
+        }
+    }
+}
+
 void autonomous_driving::AutonomousVehicle::draw_3d_preview() {
     const auto project = [&](Vec3 point) {
         return projectPoint(point, gameConfig.camera3D, static_cast<float>(ScreenWidth()), static_cast<float>(ScreenHeight()));
@@ -246,8 +313,9 @@ void autonomous_driving::AutonomousVehicle::draw_3d_preview() {
 
     const Vec3 vehicleOrigin = get_sensor_origin_3d();
     const ProjectedPoint vehicle = project(vehicleOrigin);
+    draw_vehicle_model_3d(gameConfig.camera3D, vehicleOrigin, kPi - angle);
     if (vehicle.visible) {
-        FillCircle(static_cast<int>(vehicle.screen.x), static_cast<int>(vehicle.screen.y), 5, olc::GREEN);
+        FillCircle(static_cast<int>(vehicle.screen.x), static_cast<int>(vehicle.screen.y), 3, olc::GREEN);
     }
 
     if (gameConfig.showRoboticsOverlay) {
@@ -287,8 +355,8 @@ void autonomous_driving::AutonomousVehicle::draw_gui_overlay() {
         << " | Mode: " << simulatorModeToString(gameConfig.simulatorMode)
         << " | Sensor hits " << hits << " dropouts " << dropouts;
     DrawString(16, ScreenHeight() - 78, hud.str(), olc::BLACK, 1);
-    DrawString(16, ScreenHeight() - 58, "Controls: Arrow keys drive | F1 sensor overlay | F2 2D/3D preview | TAB GUI", olc::BLACK, 1);
-    DrawString(16, ScreenHeight() - 38, "3D preview is wireframe projection on olcPGE; use authored YAML boxes for scenarios.", olc::DARK_BLUE, 1);
+    DrawString(16, ScreenHeight() - 58, "Controls: Arrow drive | F1 sensors | F2 2D/3D | TAB GUI | 3D cam WASD/QE, R reset", olc::BLACK, 1);
+    DrawString(16, ScreenHeight() - 38, "3D mode follows the procedural vehicle model with a movable third-person camera.", olc::DARK_BLUE, 1);
 }
 
 void autonomous_driving::AutonomousVehicle::universal_boundaries() {
@@ -408,6 +476,52 @@ void autonomous_driving::getYAMLData(const std::string& yaml_path, InitialConfig
         }
         if (camera["focal_length"]) {
             gameConfig.camera3D.focalLength = camera["focal_length"].as<float>();
+        }
+    }
+
+
+    if (config["third_person_camera"]) {
+        const YAML::Node thirdPerson = config["third_person_camera"];
+        if (thirdPerson["distance"]) {
+            gameConfig.thirdPersonCamera.distance = thirdPerson["distance"].as<float>();
+        }
+        if (thirdPerson["height"]) {
+            gameConfig.thirdPersonCamera.height = thirdPerson["height"].as<float>();
+        }
+        if (thirdPerson["orbit_degrees"]) {
+            gameConfig.thirdPersonCamera.orbitRadians = degreesToRadians(thirdPerson["orbit_degrees"].as<float>());
+        }
+        if (thirdPerson["min_distance"]) {
+            gameConfig.thirdPersonCamera.minDistance = thirdPerson["min_distance"].as<float>();
+        }
+        if (thirdPerson["max_distance"]) {
+            gameConfig.thirdPersonCamera.maxDistance = thirdPerson["max_distance"].as<float>();
+        }
+        if (thirdPerson["min_height"]) {
+            gameConfig.thirdPersonCamera.minHeight = thirdPerson["min_height"].as<float>();
+        }
+        if (thirdPerson["max_height"]) {
+            gameConfig.thirdPersonCamera.maxHeight = thirdPerson["max_height"].as<float>();
+        }
+    }
+
+    if (config["vehicle_model_3d"]) {
+        std::vector<VehicleModelPart3D> configuredModel;
+        for (const auto& partNode : config["vehicle_model_3d"]) {
+            float x = 0.0f;
+            float y = 0.0f;
+            float z = 0.0f;
+            float width = 0.0f;
+            float depth = 0.0f;
+            float height = 0.0f;
+            if (extractBox<float>(partNode.as<std::string>(), x, y, z, width, depth, height)) {
+                configuredModel.push_back({{x, y, z}, {width, height, depth}});
+            } else {
+                std::cerr << "Cannot Extract 3D Vehicle Model Part: " << partNode.as<std::string>() << std::endl;
+            }
+        }
+        if (!configuredModel.empty()) {
+            gameConfig.vehicleModel3D = configuredModel;
         }
     }
 

--- a/tests/simulator_3d_tests.cpp
+++ b/tests/simulator_3d_tests.cpp
@@ -51,6 +51,20 @@ int main() {
         assert(std::fabs(reading.measuredRange - 15.0f) < 1e-5f);
     }
 
+    const auto model = defaultVehicleModel3D();
+    assert(model.size() >= 3);
+    const auto corners = orientedBoxCorners({{0.0f, 0.0f, 10.0f}, {2.0f, 2.0f, 2.0f}}, {5.0f, 0.0f, 0.0f}, kPi);
+    assert(std::fabs(corners[0].x - 6.0f) < 1e-5f);
+    assert(std::fabs(corners[0].z + 9.0f) < 1e-5f);
+
+    ThirdPersonCameraConfig followConfig;
+    followConfig.distance = 100.0f;
+    followConfig.height = 50.0f;
+    const Camera3D followCamera = makeThirdPersonCamera({0.0f, 0.0f, 0.0f}, kPi, followConfig);
+    assert(std::fabs(followCamera.position.x) < 1e-4f);
+    assert(std::fabs(followCamera.position.y - 50.0f) < 1e-5f);
+    assert(std::fabs(followCamera.position.z - 140.0f) < 1e-5f);
+
     Camera3D camera;
     camera.position = {0.0f, 0.0f, 0.0f};
     camera.pitchRadians = 0.0f;


### PR DESCRIPTION
### Motivation
- Provide a movable third-person follow camera for the lightweight 3D preview so the user can inspect the vehicle from a chase-camera view. 
- Render a simple procedural 3D vehicle model in the preview to visualize vehicle pose and improve 3D sensor/debugging inspection without adding textured meshes or external asset formats.

### Description
- Add camera and model data structures and helpers: `ThirdPersonCameraConfig`, `VehicleModelPart3D`, `rotateAroundY`, `makeThirdPersonCamera`, `orientedBoxCorners`, and `defaultVehicleModel3D` in `include/simulator_3d.h` to compute follow-camera poses and oriented box corners. 
- Add runtime follow-camera controls and rendering hooks in `AutonomousVehicle`: `update_third_person_camera`, `draw_vehicle_model_3d`, and hook the camera into `OnUserUpdate` so 3D preview follows the vehicle while preserving configured focal length. 
- Extend YAML parsing in `getYAMLData` to support `third_person_camera` and `vehicle_model_3d` entries and add sensible defaults in `configs/initializeGame.yaml`. 
- Update HUD text and `README.md` to document controls (`A/D` orbit, `W/S` zoom, `Q/E` height, `R` reset), config schema, and the new procedural vehicle model rendering.

### Testing
- Built and ran unit tests with `cmake --build build && ctest --test-dir build --output-on-failure`, and all tests passed (`3/3` tests passed). 
- Ran `git diff --check` to validate whitespace/patch issues and ensured modified files staged cleanly. 
- Attempted to build the full application with `git submodule update --init --recursive && cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`, but cloning the `olcPixelGameEngine` submodule was blocked by a network 403 in this environment so the main `autonomous_car` target was skipped by CMake (unit tests still ran and passed).