### PR TITLE
Make 3D camera mouse-driven and enable WASD driving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoSIM — Autonomous Driving Simulator
 
-A 2D autonomous driving simulator with an optional lightweight 3D preview, built with [olcPixelGameEngine](https://github.com/OneLoneCoder/olcPixelGameEngine). Drive a car around the screen using the arrow keys. Configuration (window size, starting position, car sprite, scenario obstacles, sensors, and 3D preview camera) is loaded from YAML files so users can author their own scenarios without recompiling.
+A 2D autonomous driving simulator with an optional lightweight 3D preview, built with [olcPixelGameEngine](https://github.com/OneLoneCoder/olcPixelGameEngine). Drive a car around the screen using the arrow keys or WASD. Configuration (window size, starting position, car sprite, scenario obstacles, sensors, and 3D preview camera) is loaded from YAML files so users can author their own scenarios without recompiling.
 
 ![Demo Screenshot](assets/screenshot.png)
 <!-- Replace with an actual screenshot of the simulator running -->
@@ -102,9 +102,9 @@ camera_3d:
   focal_length: 520
 
 third_person_camera:
-  distance: 360                 # W/S zoom in/out
-  height: 145                   # Q/E raise/lower camera
-  orbit_degrees: 0              # A/D orbit around the vehicle; R resets
+  distance: 360                 # Mouse wheel zooms the 3D follow camera at runtime
+  height: 145                   # Left-mouse drag vertically raises/lowers camera
+  orbit_degrees: 0              # Left-mouse drag horizontally orbits; R resets
   min_distance: 140
   max_distance: 900
   min_height: 45
@@ -132,18 +132,17 @@ range_sensor:
 
 ## Controls
 
-| Key        | Action          |
+| Input      | Action          |
 |------------|-----------------|
-| ↑ Up       | Accelerate      |
-| ↓ Down     | Reverse         |
-| ← Left     | Rotate left     |
-| → Right    | Rotate right    |
+| ↑ Up / W   | Accelerate      |
+| ↓ Down / S | Reverse         |
+| ← Left / A | Rotate left     |
+| → Right / D| Rotate right    |
 | F1         | Toggle robotics/range overlay |
 | F2         | Toggle 2D / 3D preview mode |
 | Tab        | Toggle GUI/status panel |
-| A / D      | Orbit the 3D third-person camera left/right |
-| W / S      | Zoom the 3D third-person camera in/out |
-| Q / E      | Raise/lower the 3D third-person camera |
+| Left mouse drag | Orbit the 3D third-person camera left/right and raise/lower it |
+| Mouse wheel | Zoom the 3D third-person camera in/out |
 | R          | Reset the 3D third-person camera |
 
 ---

--- a/configs/initializeGame.yaml
+++ b/configs/initializeGame.yaml
@@ -31,9 +31,9 @@ camera_3d:
   focal_length: 520
 
 third_person_camera:
-  distance: 360                 # W/S zoom the follow camera in/out at runtime.
-  height: 145                   # Q/E raise/lower the follow camera.
-  orbit_degrees: 0              # A/D orbit around the vehicle; R resets to these values.
+  distance: 360                 # Mouse wheel zooms the follow camera in/out at runtime.
+  height: 145                   # Left-mouse vertical drag raises/lowers the follow camera.
+  orbit_degrees: 0              # Left-mouse horizontal drag orbits; R resets to these values.
   min_distance: 140
   max_distance: 900
   min_height: 45

--- a/include/auto_vehicle.h
+++ b/include/auto_vehicle.h
@@ -176,6 +176,16 @@ private:
     ThirdPersonCameraConfig activeThirdPersonCamera;
 
     /**
+     * @brief Last mouse X coordinate sampled while dragging the 3D camera.
+     */
+    int lastCameraMouseX = 0;
+
+    /**
+     * @brief Last mouse Y coordinate sampled while dragging the 3D camera.
+     */
+    int lastCameraMouseY = 0;
+
+    /**
      * @brief Draws robotics debugging overlays such as range rays and obstacles.
      */
     void draw_robotics_overlay();
@@ -191,7 +201,7 @@ private:
     void draw_vehicle_model_3d(const Camera3D& camera, Vec3 vehicleOrigin, float vehicleYawRadians);
 
     /**
-     * @brief Applies 3D follow-camera orbit, zoom, and height controls.
+     * @brief Applies mouse-based 3D follow-camera orbit, zoom, and height controls.
      */
     void update_third_person_camera(float fElapsedTime);
 

--- a/src/auto_vehicle.cpp
+++ b/src/auto_vehicle.cpp
@@ -48,10 +48,10 @@ bool autonomous_driving::AutonomousVehicle::OnUserUpdate(float fElapsedTime) {
     Clear(olc::WHITE);
 
     // Keyboard Events
-    const bool accelerating = GetKey(olc::Key::UP).bHeld;
-    const bool reversing = GetKey(olc::Key::DOWN).bHeld;
-    const bool steeringLeft = GetKey(olc::Key::LEFT).bHeld;
-    const bool steeringRight = GetKey(olc::Key::RIGHT).bHeld;
+    const bool accelerating = GetKey(olc::Key::UP).bHeld || GetKey(olc::Key::W).bHeld;
+    const bool reversing = GetKey(olc::Key::DOWN).bHeld || GetKey(olc::Key::S).bHeld;
+    const bool steeringLeft = GetKey(olc::Key::LEFT).bHeld || GetKey(olc::Key::A).bHeld;
+    const bool steeringRight = GetKey(olc::Key::RIGHT).bHeld || GetKey(olc::Key::D).bHeld;
 
     if (accelerating) {
         move_forward(fElapsedTime);
@@ -218,28 +218,30 @@ void autonomous_driving::AutonomousVehicle::draw_robotics_overlay() {
 
 
 void autonomous_driving::AutonomousVehicle::update_third_person_camera(float fElapsedTime) {
-    const float orbitSpeed = 1.5f * fElapsedTime;
-    const float zoomSpeed = 320.0f * fElapsedTime;
-    const float heightSpeed = 220.0f * fElapsedTime;
+    (void)fElapsedTime;
 
-    if (GetKey(olc::Key::A).bHeld) {
-        activeThirdPersonCamera.orbitRadians -= orbitSpeed;
+    const int mouseX = GetMouseX();
+    const int mouseY = GetMouseY();
+    if (GetMouse(0).bPressed) {
+        lastCameraMouseX = mouseX;
+        lastCameraMouseY = mouseY;
+    } else if (GetMouse(0).bHeld) {
+        const int deltaX = mouseX - lastCameraMouseX;
+        const int deltaY = mouseY - lastCameraMouseY;
+        constexpr float orbitRadiansPerPixel = 0.006f;
+        constexpr float heightUnitsPerPixel = 1.5f;
+        activeThirdPersonCamera.orbitRadians += static_cast<float>(deltaX) * orbitRadiansPerPixel;
+        activeThirdPersonCamera.height -= static_cast<float>(deltaY) * heightUnitsPerPixel;
+        lastCameraMouseX = mouseX;
+        lastCameraMouseY = mouseY;
     }
-    if (GetKey(olc::Key::D).bHeld) {
-        activeThirdPersonCamera.orbitRadians += orbitSpeed;
+
+    const int mouseWheelDelta = GetMouseWheel();
+    if (mouseWheelDelta != 0) {
+        constexpr float zoomUnitsPerWheelTick = 0.35f;
+        activeThirdPersonCamera.distance -= static_cast<float>(mouseWheelDelta) * zoomUnitsPerWheelTick;
     }
-    if (GetKey(olc::Key::W).bHeld) {
-        activeThirdPersonCamera.distance -= zoomSpeed;
-    }
-    if (GetKey(olc::Key::S).bHeld) {
-        activeThirdPersonCamera.distance += zoomSpeed;
-    }
-    if (GetKey(olc::Key::Q).bHeld) {
-        activeThirdPersonCamera.height += heightSpeed;
-    }
-    if (GetKey(olc::Key::E).bHeld) {
-        activeThirdPersonCamera.height -= heightSpeed;
-    }
+
     if (GetKey(olc::Key::R).bPressed) {
         activeThirdPersonCamera = gameConfig.thirdPersonCamera;
     }
@@ -355,8 +357,8 @@ void autonomous_driving::AutonomousVehicle::draw_gui_overlay() {
         << " | Mode: " << simulatorModeToString(gameConfig.simulatorMode)
         << " | Sensor hits " << hits << " dropouts " << dropouts;
     DrawString(16, ScreenHeight() - 78, hud.str(), olc::BLACK, 1);
-    DrawString(16, ScreenHeight() - 58, "Controls: Arrow drive | F1 sensors | F2 2D/3D | TAB GUI | 3D cam WASD/QE, R reset", olc::BLACK, 1);
-    DrawString(16, ScreenHeight() - 38, "3D mode follows the procedural vehicle model with a movable third-person camera.", olc::DARK_BLUE, 1);
+    DrawString(16, ScreenHeight() - 58, "Controls: Arrow/WASD drive | F1 sensors | F2 2D/3D | TAB GUI | R reset 3D cam", olc::BLACK, 1);
+    DrawString(16, ScreenHeight() - 38, "3D camera: hold left mouse and drag to orbit/raise/lower; mouse wheel zooms.", olc::DARK_BLUE, 1);
 }
 
 void autonomous_driving::AutonomousVehicle::universal_boundaries() {


### PR DESCRIPTION
### Motivation
- WASD was used for the 3D third-person camera and conflicted with driving input, preventing keyboard driving in 3D preview mode.
- A mouse-driven camera (drag to orbit/raise/lower, wheel to zoom) is more discoverable and avoids key conflicts with vehicle controls.

### Description
- Use `W/S/A/D` as alternate vehicle driving inputs by OR-ing `GetKey(olc::Key::W|A|S|D)` with the arrow keys in `src/auto_vehicle.cpp`.
- Replace keyboard-based 3D camera controls in `AutonomousVehicle::update_third_person_camera` with mouse drag (left button) for orbit/height and mouse wheel for zoom in `src/auto_vehicle.cpp`.
- Add `lastCameraMouseX` and `lastCameraMouseY` state to `include/auto_vehicle.h` to support smooth dragging.
- Update on-screen HUD text, `README.md`, and `configs/initializeGame.yaml` comments to document the new input scheme.

### Testing
- Ran `cmake -S . -B build`, which configured the project but warned that `olcPixelGameEngine.h` was missing so the runnable simulator target is skipped.
- Ran `cmake --build build` which completed successfully and built tests and available targets.
- Ran `ctest --test-dir build --output-on-failure` and all automated tests passed (`parse_tests`, `robotics_scenario_tests`, `simulator_3d_tests`).